### PR TITLE
Phase 1 · Batch 1 — Foundations: CI and tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # azsel se publica para linux y darwin (ver .goreleaser.yaml). La
+        # detección de shell y las rutas de configuración difieren entre
+        # ambos, así que conviene ejercitar los dos.
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - run: go build ./...
+
+      - run: go vet ./...
+
+      - run: go test -race ./...
+
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: gofmt
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "Estos ficheros no están formateados:"
+            echo "$unformatted"
+            echo
+            gofmt -d .
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Azure CLI stores its configuration (auth tokens, default subscription, etc.) in 
 
 Azure CLI extensions are shared across all profiles via a common `~/.azsel/extensions/` directory (using `AZURE_EXTENSION_DIR`), so you only need to install each extension once.
 
+The location of `~/.azsel/` itself can be overridden with the `AZSEL_HOME` environment variable — useful for dotfile setups, containers, or keeping separate sets of profiles:
+
+```bash
+export AZSEL_HOME=~/work/azsel
+```
+
+There is a symmetry here: `azsel` exists because `az` honours `AZURE_CONFIG_DIR`, so `azsel` honours `AZSEL_HOME` in the same spirit.
+
 Since a child process cannot modify the parent shell's environment, `azsel` writes export commands to a temporary file (`~/.azsel/.switch`) and a shell wrapper function sources it to set the variables in your current session. All visible output (TUI, messages) goes to **stderr**, keeping stdout clean.
 
 ## Installation
@@ -209,11 +217,24 @@ az webapp list --output table
 
 ## Testing
 
+### Automated tests
+
+```bash
+go test ./...
+```
+
+The suite needs neither Azure nor network access. Tests that touch configuration point `AZSEL_HOME` at a temporary directory, so running them never reads or overwrites your real `~/.azsel/`.
+
+```bash
+go test -race -cover ./...   # what CI runs
+```
+
 ### Build and verify
 
 ```bash
 go build -o azsel .
 go vet ./...
+gofmt -l .                   # must print nothing
 ```
 
 ### Manual test flow

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -46,12 +46,12 @@ func newAddCmd() *cobra.Command {
 				return fmt.Errorf("tenant ID cannot be empty")
 			}
 
-			configDir, err := config.TenantDir(name)
+			configDir, _, err := config.EnsureTenantDir(name)
 			if err != nil {
 				return err
 			}
 
-			extDir, err := config.ExtensionsDir()
+			extDir, err := config.EnsureExtensionsDir()
 			if err != nil {
 				return err
 			}

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import "testing"
+
+// nameRegex decide qué nombres de tenant se aceptan. El nombre acaba siendo
+// un directorio bajo ~/.azsel/tenants/, así que la restricción no es
+// cosmética: filtra separadores de ruta y espacios.
+func TestNameRegex(t *testing.T) {
+	cases := []struct {
+		name  string
+		valid bool
+		why   string
+	}{
+		{"a", true, "un solo carácter"},
+		{"acme", true, "minúsculas"},
+		{"acme-corp", true, "guión interior"},
+		{"client-1", true, "dígitos"},
+		{"1", true, "solo dígito"},
+		{"a-b-c-d", true, "varios guiones"},
+
+		{"", false, "vacío"},
+		{"-acme", false, "empieza por guión"},
+		{"acme-", false, "acaba en guión"},
+		{"-", false, "solo un guión"},
+		{"ACME", false, "mayúsculas"},
+		{"Acme", false, "mayúscula inicial"},
+		{"acme_corp", false, "guión bajo"},
+		{"acme corp", false, "espacio"},
+		{"acme.corp", false, "punto"},
+		{"acme/corp", false, "separador de ruta"},
+		{"..", false, "recorrido de directorios"},
+		{"acmé", false, "carácter acentuado"},
+		{"acme\n", false, "salto de línea"},
+	}
+
+	for _, c := range cases {
+		if got := nameRegex.MatchString(c.name); got != c.valid {
+			t.Errorf("nameRegex(%q) = %v, quería %v (%s)", c.name, got, c.valid, c.why)
+		}
+	}
+}

--- a/cmd/tui.go
+++ b/cmd/tui.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/aolmosj/azsel/internal/config"
 	"github.com/aolmosj/azsel/internal/tui"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/tui.go
+++ b/cmd/tui.go
@@ -31,7 +31,7 @@ func runTUI(cmd *cobra.Command, args []string) error {
 
 	if m, ok := finalModel.(tui.Model); ok {
 		if selected := m.Selected(); selected != nil {
-			extDir, err := config.ExtensionsDir()
+			extDir, err := config.EnsureExtensionsDir()
 			if err != nil {
 				return err
 			}

--- a/cmd/use.go
+++ b/cmd/use.go
@@ -25,7 +25,7 @@ func newUseCmd() *cobra.Command {
 			if _, err := os.Stat(tenant.ConfigDir); os.IsNotExist(err) {
 				return fmt.Errorf("config directory %s does not exist — try running 'azsel add' again", tenant.ConfigDir)
 			}
-			extDir, err := config.ExtensionsDir()
+			extDir, err := config.EnsureExtensionsDir()
 			if err != nil {
 				return err
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,11 @@ import (
 	"strings"
 )
 
+// EnvHome overrides where azsel keeps its own state. It exists for the same
+// reason azsel exists at all: az honours AZURE_CONFIG_DIR, so azsel honours
+// AZSEL_HOME. Tests rely on it to stay away from the real ~/.azsel.
+const EnvHome = "AZSEL_HOME"
+
 type Tenant struct {
 	Name      string `json:"name"`
 	TenantID  string `json:"tenantId"`
@@ -18,27 +23,101 @@ type Config struct {
 	Tenants []Tenant `json:"tenants"`
 }
 
+// BaseDir reports where azsel keeps its state. It only computes the path —
+// nothing is created. Use EnsureBaseDir when the directory has to exist.
 func BaseDir() (string, error) {
+	if dir := os.Getenv(EnvHome); dir != "" {
+		return dir, nil
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("getting home directory: %w", err)
 	}
-	dir := filepath.Join(home, ".azsel")
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	return filepath.Join(home, ".azsel"), nil
+}
+
+// EnsureBaseDir returns the base directory, creating it when missing.
+func EnsureBaseDir() (string, error) {
+	dir, err := BaseDir()
+	if err != nil {
+		return "", err
+	}
+	if _, err := ensureDir(dir); err != nil {
 		return "", fmt.Errorf("creating base directory: %w", err)
 	}
 	return dir, nil
 }
 
-func EnvFile() (string, error) {
+// inBase joins name onto the base directory without touching the filesystem.
+func inBase(name string) (string, error) {
 	base, err := BaseDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(base, ".switch"), nil
+	return filepath.Join(base, name), nil
+}
+
+// ensureDir creates path when missing and reports whether this call created
+// it. Callers that roll back on failure need that distinction: deleting a
+// directory somebody else put there would destroy real credentials.
+func ensureDir(path string) (created bool, err error) {
+	if _, err := os.Stat(path); err == nil {
+		return false, nil
+	} else if !os.IsNotExist(err) {
+		return false, err
+	}
+	if err := os.MkdirAll(path, 0755); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func ConfigPath() (string, error)    { return inBase("config.json") }
+func EnvFile() (string, error)       { return inBase(".switch") }
+func ExtensionsDir() (string, error) { return inBase("extensions") }
+func TenantsDir() (string, error)    { return inBase("tenants") }
+
+// TenantDir computes a tenant's config directory without creating it.
+func TenantDir(name string) (string, error) {
+	tenants, err := TenantsDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(tenants, name), nil
+}
+
+// EnsureExtensionsDir returns the shared extensions directory, creating it
+// when missing. Extensions are deliberately shared across every tenant so
+// each one only has to be installed once.
+func EnsureExtensionsDir() (string, error) {
+	dir, err := ExtensionsDir()
+	if err != nil {
+		return "", err
+	}
+	if _, err := ensureDir(dir); err != nil {
+		return "", fmt.Errorf("creating extensions directory: %w", err)
+	}
+	return dir, nil
+}
+
+// EnsureTenantDir returns a tenant's config directory, creating it when
+// missing. created reports whether this call created it.
+func EnsureTenantDir(name string) (dir string, created bool, err error) {
+	dir, err = TenantDir(name)
+	if err != nil {
+		return "", false, err
+	}
+	created, err = ensureDir(dir)
+	if err != nil {
+		return "", false, fmt.Errorf("creating tenant directory: %w", err)
+	}
+	return dir, created, nil
 }
 
 func WriteEnv(lines string) error {
+	if _, err := EnsureBaseDir(); err != nil {
+		return err
+	}
 	path, err := EnvFile()
 	if err != nil {
 		return err
@@ -47,50 +126,6 @@ func WriteEnv(lines string) error {
 		fmt.Fprintf(os.Stderr, "[azsel-debug-go] writing %s\n", path)
 	}
 	return os.WriteFile(path, []byte(lines), 0644)
-}
-
-func ConfigPath() (string, error) {
-	base, err := BaseDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(base, "config.json"), nil
-}
-
-func ExtensionsDir() (string, error) {
-	base, err := BaseDir()
-	if err != nil {
-		return "", err
-	}
-	dir := filepath.Join(base, "extensions")
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return "", fmt.Errorf("creating extensions directory: %w", err)
-	}
-	return dir, nil
-}
-
-func TenantsDir() (string, error) {
-	base, err := BaseDir()
-	if err != nil {
-		return "", err
-	}
-	dir := filepath.Join(base, "tenants")
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return "", fmt.Errorf("creating tenants directory: %w", err)
-	}
-	return dir, nil
-}
-
-func TenantDir(name string) (string, error) {
-	tenants, err := TenantsDir()
-	if err != nil {
-		return "", err
-	}
-	dir := filepath.Join(tenants, name)
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return "", fmt.Errorf("creating tenant directory: %w", err)
-	}
-	return dir, nil
 }
 
 func Load() (*Config, error) {
@@ -113,6 +148,9 @@ func Load() (*Config, error) {
 }
 
 func Save(cfg *Config) error {
+	if _, err := EnsureBaseDir(); err != nil {
+		return err
+	}
 	path, err := ConfigPath()
 	if err != nil {
 		return err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,10 +60,20 @@ func inBase(name string) (string, error) {
 // ensureDir creates path when missing and reports whether this call created
 // it. Callers that roll back on failure need that distinction: deleting a
 // directory somebody else put there would destroy real credentials.
+//
+// An existing path that is not a directory is an error. os.Stat succeeds on
+// a plain file, so without the IsDir check a file sitting where a tenant
+// directory belongs would pass for an existing profile and only blow up
+// later, inside az.
 func ensureDir(path string) (created bool, err error) {
-	if _, err := os.Stat(path); err == nil {
+	fi, err := os.Stat(path)
+	switch {
+	case err == nil:
+		if !fi.IsDir() {
+			return false, fmt.Errorf("%s exists and is not a directory", path)
+		}
 		return false, nil
-	} else if !os.IsNotExist(err) {
+	case !os.IsNotExist(err):
 		return false, err
 	}
 	if err := os.MkdirAll(path, 0755); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,377 @@
+package config_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/aolmosj/azsel/internal/config"
+)
+
+// sandbox points azsel at a throwaway directory for the duration of a test.
+// Without it these tests would read and overwrite the developer's real
+// ~/.azsel/config.json.
+func sandbox(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv(config.EnvHome, dir)
+	return dir
+}
+
+func TestBaseDirHonoursEnvHome(t *testing.T) {
+	dir := sandbox(t)
+	got, err := config.BaseDir()
+	if err != nil {
+		t.Fatalf("BaseDir: %v", err)
+	}
+	if got != dir {
+		t.Errorf("BaseDir = %q, quería %q", got, dir)
+	}
+}
+
+func TestBaseDirFallsBackToHome(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("azsel solo se publica para linux y darwin")
+	}
+	home := t.TempDir()
+	t.Setenv(config.EnvHome, "")
+	t.Setenv("HOME", home)
+
+	got, err := config.BaseDir()
+	if err != nil {
+		t.Fatalf("BaseDir: %v", err)
+	}
+	if want := filepath.Join(home, ".azsel"); got != want {
+		t.Errorf("BaseDir = %q, quería %q", got, want)
+	}
+}
+
+// Preguntar por una ruta no debe tener efectos en el disco. Antes sí los
+// tenía: cada función de ruta hacía MkdirAll.
+func TestPathFunctionsCreateNothing(t *testing.T) {
+	dir := sandbox(t)
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+
+	for _, fn := range []struct {
+		name string
+		call func() (string, error)
+	}{
+		{"BaseDir", config.BaseDir},
+		{"ConfigPath", config.ConfigPath},
+		{"EnvFile", config.EnvFile},
+		{"ExtensionsDir", config.ExtensionsDir},
+		{"TenantsDir", config.TenantsDir},
+		{"TenantDir", func() (string, error) { return config.TenantDir("acme") }},
+	} {
+		if _, err := fn.call(); err != nil {
+			t.Fatalf("%s: %v", fn.name, err)
+		}
+		if _, err := os.Stat(dir); !os.IsNotExist(err) {
+			t.Fatalf("%s creó %s", fn.name, dir)
+		}
+	}
+}
+
+func TestPathsHangOffBaseDir(t *testing.T) {
+	dir := sandbox(t)
+	cases := []struct {
+		name string
+		call func() (string, error)
+		want string
+	}{
+		{"ConfigPath", config.ConfigPath, filepath.Join(dir, "config.json")},
+		{"EnvFile", config.EnvFile, filepath.Join(dir, ".switch")},
+		{"ExtensionsDir", config.ExtensionsDir, filepath.Join(dir, "extensions")},
+		{"TenantsDir", config.TenantsDir, filepath.Join(dir, "tenants")},
+		{"TenantDir", func() (string, error) { return config.TenantDir("acme") },
+			filepath.Join(dir, "tenants", "acme")},
+	}
+	for _, c := range cases {
+		got, err := c.call()
+		if err != nil {
+			t.Fatalf("%s: %v", c.name, err)
+		}
+		if got != c.want {
+			t.Errorf("%s = %q, quería %q", c.name, got, c.want)
+		}
+	}
+}
+
+func TestEnsureBaseDirCreates(t *testing.T) {
+	dir := sandbox(t)
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	if _, err := config.EnsureBaseDir(); err != nil {
+		t.Fatalf("EnsureBaseDir: %v", err)
+	}
+	if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
+		t.Fatalf("no se creó %s: %v", dir, err)
+	}
+}
+
+// El bool 'created' es lo que permitirá a #9 revertir un login fallido sin
+// borrar un directorio preexistente con credenciales válidas.
+func TestEnsureTenantDirReportsWhoCreatedIt(t *testing.T) {
+	sandbox(t)
+
+	dir, created, err := config.EnsureTenantDir("acme")
+	if err != nil {
+		t.Fatalf("EnsureTenantDir: %v", err)
+	}
+	if !created {
+		t.Error("created = false en la primera llamada, quería true")
+	}
+	if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
+		t.Fatalf("no se creó %s: %v", dir, err)
+	}
+
+	_, created, err = config.EnsureTenantDir("acme")
+	if err != nil {
+		t.Fatalf("EnsureTenantDir (segunda): %v", err)
+	}
+	if created {
+		t.Error("created = true sobre un directorio preexistente, quería false")
+	}
+}
+
+func TestEnsureExtensionsDirCreates(t *testing.T) {
+	dir := sandbox(t)
+	got, err := config.EnsureExtensionsDir()
+	if err != nil {
+		t.Fatalf("EnsureExtensionsDir: %v", err)
+	}
+	if want := filepath.Join(dir, "extensions"); got != want {
+		t.Errorf("= %q, quería %q", got, want)
+	}
+	if fi, err := os.Stat(got); err != nil || !fi.IsDir() {
+		t.Fatalf("no se creó %s: %v", got, err)
+	}
+}
+
+func TestLoadMissingFileReturnsEmptyConfig(t *testing.T) {
+	sandbox(t)
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load sobre fichero inexistente devolvió error: %v", err)
+	}
+	if len(cfg.Tenants) != 0 {
+		t.Errorf("Tenants = %v, quería vacío", cfg.Tenants)
+	}
+}
+
+func TestLoadCorruptJSON(t *testing.T) {
+	dir := sandbox(t)
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte("{no json"), 0644); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	_, err := config.Load()
+	if err == nil {
+		t.Fatal("Load devolvió nil sobre JSON corrupto")
+	}
+	if !strings.Contains(err.Error(), "parsing config") {
+		t.Errorf("error = %q, quería que mencionara «parsing config»", err)
+	}
+}
+
+func TestSaveLoadRoundTrip(t *testing.T) {
+	sandbox(t)
+	want := &config.Config{Tenants: []config.Tenant{
+		{Name: "acme", TenantID: "11111111-1111-1111-1111-111111111111", ConfigDir: "/tmp/acme"},
+		{Name: "globex", TenantID: "22222222-2222-2222-2222-222222222222", ConfigDir: "/tmp/globex"},
+	}}
+	if err := config.Save(want); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(got.Tenants) != len(want.Tenants) {
+		t.Fatalf("%d tenants, quería %d", len(got.Tenants), len(want.Tenants))
+	}
+	for i := range want.Tenants {
+		if got.Tenants[i] != want.Tenants[i] {
+			t.Errorf("tenant %d = %+v, quería %+v", i, got.Tenants[i], want.Tenants[i])
+		}
+	}
+}
+
+// Save debe crear el directorio base si no existe: es el primer contacto
+// con el disco en una instalación nueva.
+func TestSaveCreatesBaseDir(t *testing.T) {
+	dir := sandbox(t)
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	if err := config.Save(&config.Config{}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "config.json")); err != nil {
+		t.Fatalf("no se escribió config.json: %v", err)
+	}
+}
+
+func TestFindTenantIsCaseInsensitive(t *testing.T) {
+	cfg := &config.Config{Tenants: []config.Tenant{{Name: "acme"}}}
+	for _, q := range []string{"acme", "ACME", "AcMe"} {
+		if got := cfg.FindTenant(q); got == nil {
+			t.Errorf("FindTenant(%q) = nil, quería el tenant", q)
+		}
+	}
+	if got := cfg.FindTenant("globex"); got != nil {
+		t.Errorf("FindTenant(\"globex\") = %+v, quería nil", got)
+	}
+}
+
+// FindTenant devuelve un puntero al elemento del slice, no una copia: quien
+// lo recibe puede mutar la configuración.
+func TestFindTenantReturnsPointerIntoSlice(t *testing.T) {
+	cfg := &config.Config{Tenants: []config.Tenant{{Name: "acme", TenantID: "old"}}}
+	cfg.FindTenant("acme").TenantID = "new"
+	if cfg.Tenants[0].TenantID != "new" {
+		t.Errorf("TenantID = %q, quería «new»", cfg.Tenants[0].TenantID)
+	}
+}
+
+func TestAddTenantRejectsDuplicates(t *testing.T) {
+	sandbox(t)
+	cfg := &config.Config{}
+	if err := cfg.AddTenant(config.Tenant{Name: "acme"}); err != nil {
+		t.Fatalf("AddTenant: %v", err)
+	}
+	// El duplicado se detecta sin distinguir mayúsculas, igual que FindTenant.
+	if err := cfg.AddTenant(config.Tenant{Name: "ACME"}); err == nil {
+		t.Fatal("AddTenant aceptó un duplicado")
+	}
+	if len(cfg.Tenants) != 1 {
+		t.Errorf("%d tenants, quería 1", len(cfg.Tenants))
+	}
+}
+
+func TestAddTenantPersists(t *testing.T) {
+	sandbox(t)
+	cfg := &config.Config{}
+	if err := cfg.AddTenant(config.Tenant{Name: "acme", TenantID: "x"}); err != nil {
+		t.Fatalf("AddTenant: %v", err)
+	}
+	reloaded, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if reloaded.FindTenant("acme") == nil {
+		t.Error("el tenant no se persistió")
+	}
+}
+
+func TestRemoveTenant(t *testing.T) {
+	sandbox(t)
+	cfg := &config.Config{Tenants: []config.Tenant{{Name: "acme"}, {Name: "globex"}}}
+
+	if err := cfg.RemoveTenant("ACME"); err != nil {
+		t.Fatalf("RemoveTenant: %v", err)
+	}
+	if cfg.FindTenant("acme") != nil {
+		t.Error("acme sigue presente")
+	}
+	if cfg.FindTenant("globex") == nil {
+		t.Error("RemoveTenant se llevó por delante a globex")
+	}
+
+	if err := cfg.RemoveTenant("globex"); err != nil {
+		t.Fatalf("RemoveTenant: %v", err)
+	}
+	if len(cfg.Tenants) != 0 {
+		t.Errorf("%d tenants, quería 0", len(cfg.Tenants))
+	}
+
+	reloaded, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(reloaded.Tenants) != 0 {
+		t.Errorf("en disco quedan %d tenants, quería 0", len(reloaded.Tenants))
+	}
+}
+
+func TestRemoveTenantNotFound(t *testing.T) {
+	sandbox(t)
+	cfg := &config.Config{}
+	if err := cfg.RemoveTenant("fantasma"); err == nil {
+		t.Fatal("RemoveTenant devolvió nil sobre un tenant inexistente")
+	}
+}
+
+func TestWriteEnv(t *testing.T) {
+	dir := sandbox(t)
+	const lines = "export AZURE_CONFIG_DIR=/tmp/acme\nexport AZURE_EXTENSION_DIR=/tmp/ext\n"
+	if err := config.WriteEnv(lines); err != nil {
+		t.Fatalf("WriteEnv: %v", err)
+	}
+
+	path := filepath.Join(dir, ".switch")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("leyendo .switch: %v", err)
+	}
+	if string(data) != lines {
+		t.Errorf("contenido = %q, quería %q", data, lines)
+	}
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	// Documenta el comportamiento actual; #4 valora bajarlo a 0600.
+	if perm := fi.Mode().Perm(); perm != 0644 {
+		t.Errorf("permisos = %04o, quería 0644", perm)
+	}
+}
+
+func TestWriteEnvCreatesBaseDir(t *testing.T) {
+	dir := sandbox(t)
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	if err := config.WriteEnv("export FOO=bar\n"); err != nil {
+		t.Fatalf("WriteEnv: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".switch")); err != nil {
+		t.Fatalf("no se escribió .switch: %v", err)
+	}
+}
+
+// El formato en disco es API: la función de shell y cualquier edición manual
+// dependen de estas claves.
+func TestConfigJSONShape(t *testing.T) {
+	sandbox(t)
+	if err := config.Save(&config.Config{Tenants: []config.Tenant{
+		{Name: "acme", TenantID: "tid", ConfigDir: "/tmp/acme"},
+	}}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	path, _ := config.ConfigPath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("leyendo: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	tenants, ok := raw["tenants"].([]any)
+	if !ok || len(tenants) != 1 {
+		t.Fatalf("clave «tenants» = %v", raw["tenants"])
+	}
+	first := tenants[0].(map[string]any)
+	for _, key := range []string{"name", "tenantId", "configDir"} {
+		if _, ok := first[key]; !ok {
+			t.Errorf("falta la clave %q en el JSON", key)
+		}
+	}
+}

--- a/internal/config/errors_test.go
+++ b/internal/config/errors_test.go
@@ -1,0 +1,135 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/aolmosj/azsel/internal/config"
+)
+
+// unusableHome apunta AZSEL_HOME a una ruta que cuelga de un fichero. Todo
+// intento de crear directorios ahí falla con ENOTDIR. Es más fiable que jugar
+// con permisos: root los ignoraría.
+func unusableHome(t *testing.T) {
+	t.Helper()
+	blocker := filepath.Join(t.TempDir(), "soy-un-fichero")
+	if err := os.WriteFile(blocker, nil, 0644); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	t.Setenv(config.EnvHome, filepath.Join(blocker, "azsel"))
+}
+
+func TestBaseDirFailsWithoutHome(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("azsel solo se publica para linux y darwin")
+	}
+	t.Setenv(config.EnvHome, "")
+	t.Setenv("HOME", "")
+
+	if _, err := config.BaseDir(); err == nil {
+		t.Fatal("BaseDir devolvió nil sin HOME definido")
+	} else if !strings.Contains(err.Error(), "home directory") {
+		t.Errorf("error = %q, quería que mencionara el home", err)
+	}
+}
+
+func TestEnsureFuncsFailOnUnusableBaseDir(t *testing.T) {
+	cases := []struct {
+		name string
+		call func() error
+		want string
+	}{
+		{"EnsureBaseDir", func() error {
+			_, err := config.EnsureBaseDir()
+			return err
+		}, "base directory"},
+		{"EnsureExtensionsDir", func() error {
+			_, err := config.EnsureExtensionsDir()
+			return err
+		}, "extensions directory"},
+		{"EnsureTenantDir", func() error {
+			_, _, err := config.EnsureTenantDir("acme")
+			return err
+		}, "tenant directory"},
+		{"Save", func() error { return config.Save(&config.Config{}) }, ""},
+		{"WriteEnv", func() error { return config.WriteEnv("export FOO=bar\n") }, ""},
+		{"AddTenant", func() error {
+			return (&config.Config{}).AddTenant(config.Tenant{Name: "acme"})
+		}, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			unusableHome(t)
+			err := c.call()
+			if err == nil {
+				t.Fatalf("%s devolvió nil sobre un directorio base inservible", c.name)
+			}
+			if c.want != "" && !strings.Contains(err.Error(), c.want) {
+				t.Errorf("error = %q, quería que mencionara %q", err, c.want)
+			}
+		})
+	}
+}
+
+// Un config.json que resulta ser un directorio no es «no existe»: es un error
+// de lectura real y Load debe propagarlo en vez de devolver config vacía.
+func TestLoadFailsWhenConfigPathIsADirectory(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(config.EnvHome, dir)
+	if err := os.MkdirAll(filepath.Join(dir, "config.json"), 0755); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+
+	if _, err := config.Load(); err == nil {
+		t.Fatal("Load devolvió nil con config.json siendo un directorio")
+	} else if !strings.Contains(err.Error(), "reading config") {
+		t.Errorf("error = %q, quería que mencionara «reading config»", err)
+	}
+}
+
+// Documenta una arista del comportamiento actual: si la ruta del tenant ya
+// está ocupada por un *fichero*, ensureDir ve que existe y devuelve
+// created=false sin error. El fallo aparecería más tarde, al intentar az
+// login dentro. Es un caso muy improbable y no se aborda aquí; el test
+// existe para que el cambio no pase inadvertido si alguien lo modifica.
+func TestEnsureTenantDirWhenPathIsTakenByAFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(config.EnvHome, dir)
+	tenants := filepath.Join(dir, "tenants")
+	if err := os.MkdirAll(tenants, 0755); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	// acme existe pero es un fichero; pedir un directorio debajo debe fallar.
+	if err := os.WriteFile(filepath.Join(tenants, "acme"), nil, 0644); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+
+	got, created, err := config.EnsureTenantDir("acme")
+	if err != nil {
+		t.Fatalf("EnsureTenantDir sobre un fichero existente: %v", err)
+	}
+	if created {
+		t.Error("created = true, quería false: la ruta ya estaba ocupada")
+	}
+	// Lo importante: no se reporta como creado, así que un rollback futuro
+	// (#9) no borrará algo que no puso él.
+	if got != filepath.Join(tenants, "acme") {
+		t.Errorf("dir = %q", got)
+	}
+}
+
+func TestWriteEnvWithDebugEnabled(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(config.EnvHome, dir)
+	t.Setenv("AZSEL_DEBUG", "1")
+
+	if err := config.WriteEnv("export FOO=bar\n"); err != nil {
+		t.Fatalf("WriteEnv: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".switch")); err != nil {
+		t.Fatalf("no se escribió .switch: %v", err)
+	}
+}

--- a/internal/config/errors_test.go
+++ b/internal/config/errors_test.go
@@ -90,35 +90,56 @@ func TestLoadFailsWhenConfigPathIsADirectory(t *testing.T) {
 	}
 }
 
-// Documenta una arista del comportamiento actual: si la ruta del tenant ya
-// está ocupada por un *fichero*, ensureDir ve que existe y devuelve
-// created=false sin error. El fallo aparecería más tarde, al intentar az
-// login dentro. Es un caso muy improbable y no se aborda aquí; el test
-// existe para que el cambio no pase inadvertido si alguien lo modifica.
-func TestEnsureTenantDirWhenPathIsTakenByAFile(t *testing.T) {
+// Una ruta ocupada por un fichero no es un perfil existente. os.Stat tiene
+// éxito sobre un fichero, así que sin comprobar IsDir se colaría como
+// «ya existe» y el fallo aparecería mucho después, dentro de az.
+func TestEnsureTenantDirRejectsPathTakenByAFile(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv(config.EnvHome, dir)
 	tenants := filepath.Join(dir, "tenants")
 	if err := os.MkdirAll(tenants, 0755); err != nil {
 		t.Fatalf("preparando: %v", err)
 	}
-	// acme existe pero es un fichero; pedir un directorio debajo debe fallar.
 	if err := os.WriteFile(filepath.Join(tenants, "acme"), nil, 0644); err != nil {
 		t.Fatalf("preparando: %v", err)
 	}
 
-	got, created, err := config.EnsureTenantDir("acme")
-	if err != nil {
-		t.Fatalf("EnsureTenantDir sobre un fichero existente: %v", err)
+	_, created, err := config.EnsureTenantDir("acme")
+	if err == nil {
+		t.Fatal("EnsureTenantDir devolvió nil sobre una ruta ocupada por un fichero")
 	}
+	if !strings.Contains(err.Error(), "not a directory") {
+		t.Errorf("error = %q, quería que mencionara «not a directory»", err)
+	}
+	// Nada creado: un rollback futuro (#9) no debe borrar lo que no puso él.
 	if created {
-		t.Error("created = true, quería false: la ruta ya estaba ocupada")
+		t.Error("created = true, quería false")
 	}
-	// Lo importante: no se reporta como creado, así que un rollback futuro
-	// (#9) no borrará algo que no puso él.
-	if got != filepath.Join(tenants, "acme") {
-		t.Errorf("dir = %q", got)
-	}
+}
+
+// Lo mismo para el directorio base y el de extensiones.
+func TestEnsureDirsRejectPathTakenByAFile(t *testing.T) {
+	t.Run("base", func(t *testing.T) {
+		blocker := filepath.Join(t.TempDir(), "azsel")
+		if err := os.WriteFile(blocker, nil, 0644); err != nil {
+			t.Fatalf("preparando: %v", err)
+		}
+		t.Setenv(config.EnvHome, blocker)
+		if _, err := config.EnsureBaseDir(); err == nil {
+			t.Fatal("EnsureBaseDir devolvió nil sobre un fichero")
+		}
+	})
+
+	t.Run("extensions", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Setenv(config.EnvHome, dir)
+		if err := os.WriteFile(filepath.Join(dir, "extensions"), nil, 0644); err != nil {
+			t.Fatalf("preparando: %v", err)
+		}
+		if _, err := config.EnsureExtensionsDir(); err == nil {
+			t.Fatal("EnsureExtensionsDir devolvió nil sobre un fichero")
+		}
+	})
 }
 
 func TestWriteEnvWithDebugEnabled(t *testing.T) {

--- a/internal/tui/delegate.go
+++ b/internal/tui/delegate.go
@@ -19,8 +19,8 @@ func newDelegate() tenantDelegate {
 	return tenantDelegate{}
 }
 
-func (d tenantDelegate) Height() int                             { return 2 }
-func (d tenantDelegate) Spacing() int                            { return 1 }
+func (d tenantDelegate) Height() int  { return 2 }
+func (d tenantDelegate) Spacing() int { return 1 }
 func (d tenantDelegate) Update(msg tea.Msg, m *list.Model) tea.Cmd {
 	if msg, ok := msg.(tea.KeyMsg); ok {
 		if msg.String() == "enter" {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1,0 +1,192 @@
+package tui
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/aolmosj/azsel/internal/config"
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func tenants() []config.Tenant {
+	return []config.Tenant{
+		{Name: "acme", TenantID: "11111111-1111-1111-1111-111111111111", ConfigDir: "/home/u/.azsel/tenants/acme"},
+		{Name: "globex", TenantID: "22222222-2222-2222-2222-222222222222", ConfigDir: "/home/u/.azsel/tenants/globex"},
+	}
+}
+
+func keyMsg(s string) tea.KeyMsg {
+	if s == "enter" {
+		return tea.KeyMsg{Type: tea.KeyEnter}
+	}
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+}
+
+// send aplica una secuencia de mensajes y devuelve el modelo resultante junto
+// al último comando emitido.
+func send(t *testing.T, m Model, msgs ...tea.Msg) (Model, tea.Cmd) {
+	t.Helper()
+	var cmd tea.Cmd
+	for _, msg := range msgs {
+		next, c := m.Update(msg)
+		got, ok := next.(Model)
+		if !ok {
+			t.Fatalf("Update devolvió %T, quería tui.Model", next)
+		}
+		m, cmd = got, c
+	}
+	return m, cmd
+}
+
+// El tenant activo se deduce comparando ConfigDir con AZURE_CONFIG_DIR. No se
+// guarda en ningún sitio, lo que permite que cada terminal tenga el suyo.
+func TestNewModelMarksActiveTenant(t *testing.T) {
+	ts := tenants()
+	m := NewModel(ts, ts[1].ConfigDir)
+
+	items := m.list.Items()
+	if len(items) != 2 {
+		t.Fatalf("%d items, quería 2", len(items))
+	}
+	if items[0].(TenantItem).active {
+		t.Error("acme marcado como activo")
+	}
+	if !items[1].(TenantItem).active {
+		t.Error("globex no marcado como activo")
+	}
+}
+
+func TestNewModelNoActiveTenant(t *testing.T) {
+	for _, dir := range []string{"", "/otro/sitio"} {
+		m := NewModel(tenants(), dir)
+		for _, it := range m.list.Items() {
+			if it.(TenantItem).active {
+				t.Errorf("con AZURE_CONFIG_DIR=%q hay un tenant marcado activo", dir)
+			}
+		}
+	}
+}
+
+func TestSelectedIsNilUntilChosen(t *testing.T) {
+	m := NewModel(tenants(), "")
+	if got := m.Selected(); got != nil {
+		t.Errorf("Selected() = %+v antes de elegir, quería nil", got)
+	}
+}
+
+func TestSelectTenantMsgSetsSelection(t *testing.T) {
+	ts := tenants()
+	m := NewModel(ts, "")
+	m, _ = send(t, m, selectTenantMsg{tenant: NewTenantItem(ts[1], false)})
+
+	got := m.Selected()
+	if got == nil {
+		t.Fatal("Selected() = nil tras seleccionar")
+	}
+	if got.Name != "globex" {
+		t.Errorf("Selected().Name = %q, quería «globex»", got.Name)
+	}
+	// Sale de la TUI y deja de pintar.
+	if v := m.View(); v != "" {
+		t.Errorf("View() = %q tras seleccionar, quería vacío", v)
+	}
+}
+
+// Pulsar enter sobre un item debe emitir selectTenantMsg. Es el delegate quien
+// lo produce, no el modelo.
+func TestEnterEmitsSelectTenantMsg(t *testing.T) {
+	m := NewModel(tenants(), "")
+	_, cmd := send(t, m, keyMsg("enter"))
+	if cmd == nil {
+		t.Fatal("enter no emitió ningún comando")
+	}
+	if _, ok := cmd().(selectTenantMsg); !ok {
+		t.Fatalf("enter emitió %T, quería selectTenantMsg", cmd())
+	}
+}
+
+func TestQuitKeys(t *testing.T) {
+	for _, k := range []tea.KeyMsg{keyMsg("q"), {Type: tea.KeyCtrlC}} {
+		m := NewModel(tenants(), "")
+		m, _ = send(t, m, k)
+		if v := m.View(); v != "" {
+			t.Errorf("tras %v, View() = %q, quería vacío", k, v)
+		}
+		if m.Selected() != nil {
+			t.Errorf("tras %v hay selección, quería nil", k)
+		}
+	}
+}
+
+// Protege la guarda de Update: mientras se filtra, «q» es texto de búsqueda,
+// no la orden de salir. Sin ella, buscar «quux» cerraría la aplicación.
+func TestQuitKeyIsTextWhileFiltering(t *testing.T) {
+	m := NewModel(tenants(), "")
+	m, _ = send(t, m, keyMsg("/"))
+	if m.list.FilterState() != list.Filtering {
+		t.Fatalf("«/» no entró en modo filtro: estado = %v", m.list.FilterState())
+	}
+
+	m, _ = send(t, m, keyMsg("q"))
+	if v := m.View(); v == "" {
+		t.Error("«q» durante el filtrado cerró la TUI")
+	}
+	if m.Selected() != nil {
+		t.Error("«q» durante el filtrado dejó una selección")
+	}
+}
+
+// El filtro busca por nombre y por ID: pegar un GUID debe encontrar su tenant.
+func TestFilterValueCoversNameAndID(t *testing.T) {
+	item := NewTenantItem(tenants()[0], false)
+	got := item.FilterValue()
+	if !strings.Contains(got, "acme") {
+		t.Errorf("FilterValue() = %q, quería que incluyera el nombre", got)
+	}
+	if !strings.Contains(got, "11111111-1111-1111-1111-111111111111") {
+		t.Errorf("FilterValue() = %q, quería que incluyera el tenant ID", got)
+	}
+}
+
+func TestWindowSizeMsgResizesList(t *testing.T) {
+	m := NewModel(tenants(), "")
+	m, _ = send(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	if w := m.list.Width(); w >= 120 {
+		t.Errorf("ancho de la lista = %d, quería descontar el margen de 120", w)
+	}
+	if h := m.list.Height(); h >= 40 {
+		t.Errorf("alto de la lista = %d, quería descontar el margen de 40", h)
+	}
+}
+
+// El delegate pinta dos líneas por tenant, nombre e ID, y marca el activo.
+func TestDelegateRender(t *testing.T) {
+	ts := tenants()
+	m := NewModel(ts, ts[0].ConfigDir)
+	d := newDelegate()
+
+	if got := d.Height(); got != 2 {
+		t.Errorf("Height() = %d, quería 2 (nombre + ID)", got)
+	}
+
+	var buf bytes.Buffer
+	d.Render(&buf, m.list, 0, m.list.Items()[0])
+	out := buf.String()
+	if !strings.Contains(out, "acme") {
+		t.Errorf("render = %q, quería el nombre", out)
+	}
+	if !strings.Contains(out, ts[0].TenantID) {
+		t.Errorf("render = %q, quería el tenant ID", out)
+	}
+	if !strings.Contains(out, "*") {
+		t.Errorf("render = %q, quería el marcador «*» del tenant activo", out)
+	}
+
+	buf.Reset()
+	d.Render(&buf, m.list, 1, m.list.Items()[1])
+	if out := buf.String(); strings.Contains(out, "*") {
+		t.Errorf("render del tenant inactivo = %q, no quería marcador", out)
+	}
+}


### PR DESCRIPTION
First batch of Phase 1 (#13): the safety net that the following batches rely on.

## Scope

- [x] #11 — CI: build, vet, test and gofmt workflow
- [x] #7 — Initial test suite

## #11 — CI

Until now the only workflow was `release.yaml`, triggered by `v*` tags. Nothing checked pushes or pull requests.

Adds `.github/workflows/ci.yaml`:

- **`test`** — `ubuntu-latest` + `macos-latest` matrix with `go build`, `go vet` and `go test -race`. Both platforms matter: `azsel` ships for linux and darwin, and the shell detection in `cmd/init.go` takes different paths on each.
- **`format`** — fails if `gofmt -l` returns anything, showing the diff.

The tree wasn't formatted, so the `format` job would have failed from day one. Fixed the two files: import ordering in `cmd/tui.go` and `Height`/`Spacing` alignment in `internal/tui/delegate.go`.

`golangci-lint` is left out on purpose: the issue framed it as "consider", and it would almost certainly open unplanned work in the middle of Phase 1.

## #7 — Tests

### The underlying problem

The entire `config` package hung off `BaseDir()`, with `os.UserHomeDir()` wired in. **You couldn't write a single test**: calling `config.Save()` from a test overwrote the developer's real `~/.azsel/config.json` and wiped out their tenants.

### `AZSEL_HOME`

`BaseDir()` now respects `AZSEL_HOME` before falling back to `~/.azsel`. Tests point it at `t.TempDir()`; users gain a way to relocate their profiles (dotfiles, containers, sets kept separate from tenants).

There's a symmetry to it: `azsel` exists because `az` respects `AZURE_CONFIG_DIR`, so `azsel` respects `AZSEL_HOME` in the same spirit. Documented in the README.

### Pure paths vs. explicit creation

The path functions created directories as a side effect of being asked for a path — four `MkdirAll` calls that made `azsel list` create `~/.azsel` just for asking where the config lived.

```go
TenantDir(name)        (string, error)         // computes, doesn't touch the disk
EnsureTenantDir(name)  (string, bool, error)   // creates; the bool says whether this call created it
```

That `bool` is exactly what **#9** needs to roll back a failed login without deleting a pre-existing directory full of valid credentials.

### Coverage

42 tests across three packages:

| Package | What it covers | Coverage |
|---|---|---|
| `internal/config` | round-trips, corrupt JSON, case-insensitive lookup, duplicate rejection, `.switch` content and permissions, and the error paths with an unusable base directory | 87.5% |
| `internal/tui` | marking the active tenant, selection, delegate render, and the guard that stops "q" from closing the TUI while the filter is open | 87.5% |
| `cmd` | table of cases for the tenant-name regex, including directory traversal and separators | — |

The suite needs neither Azure nor network, and no test touches the real `$HOME`.

### Out of scope

`internal/azure` still has no tests: it runs `az` as a subprocess and the executor needs to be injected first. The issue itself marks it as lower priority.

---

Closes #11
Closes #7