### PR TITLE
Phase 1 · Batch 2 — Shell integration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,19 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # The wrapper is installed into both bash and zsh, and the shell tests
+      # skip whichever interpreter is missing. Without this, coverage would
+      # depend on what the runner image happens to ship and a silent skip
+      # would pass for a green run.
+      - name: Install zsh
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y zsh
+
+      - name: Shells under test
+        run: |
+          bash --version | head -1
+          zsh --version
+
       - run: go build ./...
 
       - run: go vet ./...

--- a/README.md
+++ b/README.md
@@ -293,8 +293,8 @@ This outputs trace information to stderr showing:
 
 ```
 [azsel-debug] args: use contoso
-[azsel-debug] binary: /usr/local/bin/azsel
 [azsel-debug] switch file: /Users/you/.azsel/.switch.48231
+[azsel-debug-go] binary: /usr/local/bin/azsel
 [azsel-debug-go] writing /Users/you/.azsel/.switch.48231
 Switched to tenant "contoso"
 [azsel-debug] sourcing /Users/you/.azsel/.switch.48231
@@ -302,6 +302,8 @@ export AZURE_CONFIG_DIR=/Users/you/.azsel/tenants/contoso
 export AZURE_EXTENSION_DIR=/Users/you/.azsel/extensions
 [azsel-debug] AZURE_CONFIG_DIR=/Users/you/.azsel/tenants/contoso
 ```
+
+Lines prefixed `[azsel-debug]` come from the shell wrapper, `[azsel-debug-go]` from the binary itself.
 
 To disable, unset the variable:
 

--- a/README.md
+++ b/README.md
@@ -98,8 +98,10 @@ Logging in to tenant "contoso" (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)...
 # Browser opens for Azure login...
 
 Tenant "contoso" added successfully.
-To activate: eval $(azsel use contoso)
+To activate: azsel use contoso
 ```
+
+If shell integration is not set up, `azsel add` says so rather than leaving you to find out when `azsel use` appears to do nothing.
 
 Use `--device-code` to authenticate via device code flow instead of opening a browser (useful for remote/headless machines):
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ export AZSEL_HOME=~/work/azsel
 
 There is a symmetry here: `azsel` exists because `az` honours `AZURE_CONFIG_DIR`, so `azsel` honours `AZSEL_HOME` in the same spirit.
 
-Since a child process cannot modify the parent shell's environment, `azsel` writes export commands to a temporary file (`~/.azsel/.switch`) and a shell wrapper function sources it to set the variables in your current session. All visible output (TUI, messages) goes to **stderr**, keeping stdout clean.
+Since a child process cannot modify the parent shell's environment, `azsel` writes export commands to a temporary file and a shell wrapper function sources it to set the variables in your current session. All visible output (TUI, messages) goes to **stderr**, keeping stdout clean.
+
+That file is **per shell**: the wrapper points `AZSEL_SWITCH_FILE` at `~/.azsel/.switch.$$`, keyed by the shell's PID. A single shared file meant one terminal could consume and delete a switch another terminal had not sourced yet. Files left behind by a shell that died mid-switch are swept after 24 hours.
 
 ## Installation
 
@@ -206,14 +208,19 @@ azsel use client-b
 
 ### Use in scripts
 
-In scripts, source the `.switch` file after running `azsel use`:
+In scripts, point `AZSEL_SWITCH_FILE` at a file of your own and source it after running `azsel use`:
 
 ```bash
 #!/bin/bash
+export AZSEL_SWITCH_FILE="$(mktemp)"
 command azsel use staging-tenant
-source "$HOME/.azsel/.switch"
+source "$AZSEL_SWITCH_FILE"
+rm -f "$AZSEL_SWITCH_FILE"
+
 az webapp list --output table
 ```
+
+With `AZSEL_SWITCH_FILE` unset, `azsel` falls back to `~/.azsel/.switch`, so scripts written against the older layout keep working.
 
 ## Testing
 
@@ -287,9 +294,10 @@ This outputs trace information to stderr showing:
 ```
 [azsel-debug] args: use contoso
 [azsel-debug] binary: /usr/local/bin/azsel
-[azsel-debug-go] writing /Users/you/.azsel/.switch
+[azsel-debug] switch file: /Users/you/.azsel/.switch.48231
+[azsel-debug-go] writing /Users/you/.azsel/.switch.48231
 Switched to tenant "contoso"
-[azsel-debug] sourcing /Users/you/.azsel/.switch
+[azsel-debug] sourcing /Users/you/.azsel/.switch.48231
 export AZURE_CONFIG_DIR=/Users/you/.azsel/tenants/contoso
 export AZURE_EXTENSION_DIR=/Users/you/.azsel/extensions
 [azsel-debug] AZURE_CONFIG_DIR=/Users/you/.azsel/tenants/contoso

--- a/README.md
+++ b/README.md
@@ -36,11 +36,43 @@ Since a child process cannot modify the parent shell's environment, `azsel` writ
 
 That file is **per shell**: the wrapper points `AZSEL_SWITCH_FILE` at `~/.azsel/.switch.$$`, keyed by the shell's PID. A single shared file meant one terminal could consume and delete a switch another terminal had not sourced yet. Files left behind by a shell that died mid-switch are swept after 24 hours.
 
+## Compatibility
+
+### Shells
+
+Shell integration is what lets `azsel use` change the tenant in your *current* session. "Supported" means `azsel init` finds your profile and the generated wrapper works there.
+
+| Shell | Status | Notes |
+|---|---|---|
+| zsh | Supported | detected, installed into `~/.zshrc` |
+| bash | Supported | `~/.bashrc`, falling back to `~/.bash_profile` on macOS. Tested down to bash 3.2, the version macOS ships |
+| fish | Not supported | the wrapper uses `local`, `[[ ]]` and `source`; fish cannot parse it |
+| sh / dash | Not supported | `[[ ]]` is not POSIX |
+
+On an unsupported shell everything else still works. Run `azsel use <name>` and source the file it writes yourself — see [Use in scripts](#use-in-scripts). `azsel init` will tell you this rather than suggesting a line that would not work.
+
+### Operating systems
+
+| OS | Status |
+|---|---|
+| macOS | Supported — arm64 and amd64 |
+| Linux | Supported — arm64 and amd64 |
+| Windows | Not built, and the shell integration does not apply |
+
+CI runs the test suite on Linux and macOS, exercising the wrapper under both bash and zsh on each.
+
+### Dependencies
+
+| Dependency | Requirement |
+|---|---|
+| Azure CLI | Any version honouring `AZURE_CONFIG_DIR` and `AZURE_EXTENSION_DIR`. Verified against 2.87.0; the practical floor is older but has not been pinned down |
+| Go | Only needed to build from source. See `go.mod` for the version in force |
+
 ## Installation
 
 ### Prerequisites
 
-- [Go 1.22+](https://go.dev/dl/)
+- [Go](https://go.dev/dl/) — version as declared in `go.mod` (currently 1.24), only to build from source
 - [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli) (`az`) installed and available in `PATH`
 
 ### Build from source

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -71,11 +71,31 @@ func newAddCmd() *cobra.Command {
 			}
 
 			fmt.Fprintf(os.Stderr, "\nTenant %q added successfully.\n", name)
-			fmt.Fprintf(os.Stderr, "To activate: eval $(azsel use %s)\n", name)
+			fmt.Fprint(os.Stderr, activationHint(name, os.Getenv(config.EnvSwitchFile) != ""))
 			return nil
 		},
 	}
 
 	c.Flags().BoolVar(&useDeviceCode, "device-code", false, "Use device code flow instead of opening a browser")
 	return c
+}
+
+// activationHint explains how to activate a freshly added tenant.
+//
+// It used to suggest `eval $(azsel use NAME)`, which does nothing: use writes
+// the export snippet to a file and reports to stderr, so the command
+// substitution captures an empty string. Users with shell integration saw it
+// work anyway — the wrapper sourced the file — which made the wrong advice
+// look right.
+//
+// The wrapper sets EnvSwitchFile when invoking the binary, so its absence is
+// a reliable sign that integration is not installed. Worth saying out loud
+// here: without it, `azsel use` cannot reach the caller's shell at all.
+func activationHint(name string, integrationActive bool) string {
+	hint := fmt.Sprintf("To activate: azsel use %s\n", name)
+	if integrationActive {
+		return hint
+	}
+	return hint + "\nShell integration does not look active. Run 'azsel init' and reload your\n" +
+		"shell — otherwise 'azsel use' cannot change AZURE_CONFIG_DIR in your session.\n"
 }

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -71,7 +71,7 @@ func newAddCmd() *cobra.Command {
 			}
 
 			fmt.Fprintf(os.Stderr, "\nTenant %q added successfully.\n", name)
-			fmt.Fprint(os.Stderr, activationHint(name, os.Getenv(config.EnvSwitchFile) != ""))
+			fmt.Fprint(os.Stderr, activationHint(name, shellIntegrationInstalled()))
 			return nil
 		},
 	}
@@ -91,6 +91,24 @@ func newAddCmd() *cobra.Command {
 // The wrapper sets EnvSwitchFile when invoking the binary, so its absence is
 // a reliable sign that integration is not installed. Worth saying out loud
 // here: without it, `azsel use` cannot reach the caller's shell at all.
+// shellIntegrationInstalled reports whether the wrapper looks set up.
+//
+// EnvSwitchFile is set by the wrapper itself, so it is the strongest signal —
+// but `command azsel add` deliberately bypasses the wrapper, and so does any
+// script. Falling back to the rc file avoids telling a correctly configured
+// user to run `azsel init`, which would just answer "already configured" and
+// leave them stuck.
+func shellIntegrationInstalled() bool {
+	if os.Getenv(config.EnvSwitchFile) != "" {
+		return true
+	}
+	rcFile, _, err := detectShellRC()
+	if err != nil || rcFile == "" {
+		return false
+	}
+	return rcContainsInit(rcFile)
+}
+
 func activationHint(name string, integrationActive bool) string {
 	hint := fmt.Sprintf("To activate: azsel use %s\n", name)
 	if integrationActive {

--- a/cmd/hint_test.go
+++ b/cmd/hint_test.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// El mensaje sugería `eval $(azsel use NAME)`, que no hace nada: use escribe
+// el snippet en un fichero y reporta por stderr, así que la sustitución de
+// comandos captura la cadena vacía y `eval ""` es un no-op.
+func TestActivationHintNeverSuggestsEval(t *testing.T) {
+	for _, active := range []bool{true, false} {
+		got := activationHint("acme", active)
+		if strings.Contains(got, "eval") {
+			t.Errorf("integración=%v: el mensaje sigue sugiriendo eval:\n%s", active, got)
+		}
+		if !strings.Contains(got, "azsel use acme") {
+			t.Errorf("integración=%v: falta la orden real:\n%s", active, got)
+		}
+	}
+}
+
+// Con la integración activa el mensaje debe ser una sola instrucción, sin
+// ruido: el usuario ya lo tiene todo montado.
+func TestActivationHintIsTerseWhenIntegrationActive(t *testing.T) {
+	got := activationHint("acme", true)
+	if want := "To activate: azsel use acme\n"; got != want {
+		t.Errorf("mensaje = %q, quería %q", got, want)
+	}
+}
+
+// Sin integración, `azsel use` no puede alcanzar el shell del usuario. Hay que
+// decirlo, no dejar que lo descubra por su cuenta.
+func TestActivationHintWarnsWithoutIntegration(t *testing.T) {
+	got := activationHint("acme", false)
+	if !strings.Contains(got, "azsel init") {
+		t.Errorf("el aviso no menciona 'azsel init':\n%s", got)
+	}
+	if !strings.Contains(got, "AZURE_CONFIG_DIR") {
+		t.Errorf("el aviso no explica la consecuencia:\n%s", got)
+	}
+}
+
+// El nombre se interpola, no se pierde.
+func TestActivationHintUsesTenantName(t *testing.T) {
+	if got := activationHint("globex-prod", true); !strings.Contains(got, "globex-prod") {
+		t.Errorf("mensaje = %q, quería el nombre del tenant", got)
+	}
+}

--- a/cmd/hint_test.go
+++ b/cmd/hint_test.go
@@ -1,8 +1,12 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/aolmosj/azsel/internal/config"
 )
 
 // El mensaje sugería `eval $(azsel use NAME)`, que no hace nada: use escribe
@@ -46,4 +50,50 @@ func TestActivationHintUsesTenantName(t *testing.T) {
 	if got := activationHint("globex-prod", true); !strings.Contains(got, "globex-prod") {
 		t.Errorf("mensaje = %q, quería el nombre del tenant", got)
 	}
+}
+
+// `command azsel add` esquiva el wrapper a propósito, igual que cualquier
+// script. Mirar solo AZSEL_SWITCH_FILE le decía a un usuario correctamente
+// configurado que ejecutara `azsel init`, que respondería "already
+// configured" y lo dejaría sin salida.
+func TestShellIntegrationInstalled(t *testing.T) {
+	t.Run("variable del wrapper presente", func(t *testing.T) {
+		t.Setenv(config.EnvSwitchFile, "/tmp/.switch.1")
+		if !shellIntegrationInstalled() {
+			t.Error("no se detectó la integración con la variable definida")
+		}
+	})
+
+	t.Run("wrapper esquivado pero rc configurado", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("SHELL", "/bin/zsh")
+		t.Setenv(config.EnvSwitchFile, "")
+		if err := os.WriteFile(filepath.Join(home, ".zshrc"),
+			[]byte("\n"+initLine+"\n"), 0644); err != nil {
+			t.Fatalf("preparando: %v", err)
+		}
+		if !shellIntegrationInstalled() {
+			t.Error("no se detectó la integración leyendo el rc")
+		}
+	})
+
+	t.Run("sin integración", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("SHELL", "/bin/zsh")
+		t.Setenv(config.EnvSwitchFile, "")
+		if shellIntegrationInstalled() {
+			t.Error("se detectó integración donde no la hay")
+		}
+	})
+
+	t.Run("shell no soportado", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		t.Setenv("SHELL", "/usr/bin/fish")
+		t.Setenv(config.EnvSwitchFile, "")
+		if shellIntegrationInstalled() {
+			t.Error("se detectó integración en un shell no soportado")
+		}
+	})
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -12,12 +12,15 @@ import (
 const initLine = `eval "$(azsel init --print)"`
 
 const shellFunc = `azsel() {
+  # One switch file per shell, keyed by PID. A single shared file let one
+  # terminal consume and delete another's pending switch.
+  local _azsel_f="${AZSEL_HOME:-$HOME/.azsel}/.switch.$$"
   if [[ -n "$AZSEL_DEBUG" ]]; then
     echo "[azsel-debug] args: $*" >&2
     echo "[azsel-debug] binary: $(whence -p azsel 2>&1)" >&2
+    echo "[azsel-debug] switch file: $_azsel_f" >&2
   fi
-  command azsel "$@"
-  local _azsel_f="$HOME/.azsel/.switch"
+  AZSEL_SWITCH_FILE="$_azsel_f" command azsel "$@"
   if [[ -f "$_azsel_f" ]]; then
     if [[ -n "$AZSEL_DEBUG" ]]; then
       echo "[azsel-debug] sourcing $_azsel_f" >&2

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -17,7 +17,6 @@ const shellFunc = `azsel() {
   local _azsel_f="${AZSEL_HOME:-$HOME/.azsel}/.switch.$$"
   if [[ -n "$AZSEL_DEBUG" ]]; then
     echo "[azsel-debug] args: $*" >&2
-    echo "[azsel-debug] binary: $(whence -p azsel 2>&1)" >&2
     echo "[azsel-debug] switch file: $_azsel_f" >&2
   fi
   AZSEL_SWITCH_FILE="$_azsel_f" command azsel "$@"

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -15,11 +15,16 @@ const shellFunc = `azsel() {
   # One switch file per shell, keyed by PID. A single shared file let one
   # terminal consume and delete another's pending switch.
   local _azsel_f="${AZSEL_HOME:-$HOME/.azsel}/.switch.$$"
+  # Clear the path before running: PIDs get reused, so a file orphaned by a
+  # shell that died mid-switch would otherwise be sourced later by an
+  # unrelated command in a shell that happens to reuse its PID.
+  command rm -f "$_azsel_f"
   if [[ -n "$AZSEL_DEBUG" ]]; then
     echo "[azsel-debug] args: $*" >&2
     echo "[azsel-debug] switch file: $_azsel_f" >&2
   fi
   AZSEL_SWITCH_FILE="$_azsel_f" command azsel "$@"
+  local _azsel_rc=$?
   if [[ -f "$_azsel_f" ]]; then
     if [[ -n "$AZSEL_DEBUG" ]]; then
       echo "[azsel-debug] sourcing $_azsel_f" >&2
@@ -31,35 +36,52 @@ const shellFunc = `azsel() {
       echo "[azsel-debug] AZURE_CONFIG_DIR=$AZURE_CONFIG_DIR" >&2
     fi
   elif [[ -n "$AZSEL_DEBUG" ]]; then
-    echo "[azsel-debug] no .switch file" >&2
+    echo "[azsel-debug] no switch file" >&2
   fi
+  return $_azsel_rc
 }`
 
 // detectShellRC reports the rc file to install the wrapper into, plus the
 // shell it detected. An empty rcFile means azsel cannot integrate with that
 // shell; shellName is still returned so the caller can say which one it was.
-func detectShellRC() (rcFile, shellName string) {
+func detectShellRC() (rcFile, shellName string, err error) {
 	shell := os.Getenv("SHELL")
 	if shell != "" {
 		shellName = filepath.Base(shell)
 	}
+	// A failing home lookup is its own problem, not an unsupported shell.
+	// Reporting it as the latter would tell a zsh user that zsh is not
+	// supported, which the next few lines contradict.
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return "", shellName
+		return "", "", fmt.Errorf("getting home directory: %w", err)
 	}
 	switch shellName {
 	case "zsh":
-		return filepath.Join(home, ".zshrc"), shellName
+		return filepath.Join(home, ".zshrc"), shellName, nil
 	case "bash":
 		// Prefer .bashrc, fall back to .bash_profile on macOS
 		bashrc := filepath.Join(home, ".bashrc")
 		if _, err := os.Stat(bashrc); err == nil {
-			return bashrc, shellName
+			return bashrc, shellName, nil
 		}
-		return filepath.Join(home, ".bash_profile"), shellName
+		return filepath.Join(home, ".bash_profile"), shellName, nil
 	default:
-		return "", shellName
+		return "", shellName, nil
 	}
+}
+
+// initMarker is what identifies an already-installed integration line inside
+// a shell rc file.
+const initMarker = "azsel init"
+
+// rcContainsInit reports whether the rc file already wires up azsel.
+func rcContainsInit(rcFile string) bool {
+	data, err := os.ReadFile(rcFile)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(data), initMarker)
 }
 
 // unsupportedShellError explains what azsel can and cannot do here.
@@ -98,7 +120,10 @@ func newInitCmd() *cobra.Command {
 				return nil
 			}
 
-			rcFile, shellName := detectShellRC()
+			rcFile, shellName, err := detectShellRC()
+			if err != nil {
+				return err
+			}
 			if rcFile == "" {
 				return unsupportedShellError(shellName)
 			}
@@ -108,7 +133,7 @@ func newInitCmd() *cobra.Command {
 				return fmt.Errorf("reading %s: %w", rcFile, err)
 			}
 
-			if strings.Contains(string(data), "azsel init") {
+			if strings.Contains(string(data), initMarker) {
 				fmt.Fprintf(os.Stderr, "Already configured in %s — no changes made.\n", rcFile)
 				return nil
 			}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -35,25 +35,53 @@ const shellFunc = `azsel() {
   fi
 }`
 
-func detectShellRC() string {
+// detectShellRC reports the rc file to install the wrapper into, plus the
+// shell it detected. An empty rcFile means azsel cannot integrate with that
+// shell; shellName is still returned so the caller can say which one it was.
+func detectShellRC() (rcFile, shellName string) {
 	shell := os.Getenv("SHELL")
+	if shell != "" {
+		shellName = filepath.Base(shell)
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return ""
+		return "", shellName
 	}
-	switch filepath.Base(shell) {
+	switch shellName {
 	case "zsh":
-		return filepath.Join(home, ".zshrc")
+		return filepath.Join(home, ".zshrc"), shellName
 	case "bash":
 		// Prefer .bashrc, fall back to .bash_profile on macOS
 		bashrc := filepath.Join(home, ".bashrc")
 		if _, err := os.Stat(bashrc); err == nil {
-			return bashrc
+			return bashrc, shellName
 		}
-		return filepath.Join(home, ".bash_profile")
+		return filepath.Join(home, ".bash_profile"), shellName
 	default:
-		return ""
+		return "", shellName
 	}
+}
+
+// unsupportedShellError explains what azsel can and cannot do here.
+//
+// The previous message said "add this manually to your shell rc", which is
+// wrong for fish: the wrapper is written in bash/zsh syntax that fish cannot
+// parse, so following the advice fails. Suggest the line only where it has a
+// chance of working, and point at the escape hatch that always does.
+func unsupportedShellError(shellName string) error {
+	which := "your shell could not be detected from $SHELL"
+	if shellName != "" {
+		which = fmt.Sprintf("%q is not one of them", shellName)
+	}
+	return fmt.Errorf(`azsel's shell integration is written for bash and zsh — %s.
+
+The wrapper uses bash/zsh syntax, so adding it to a shell like fish will not
+work. If your shell is bash-compatible you can add this line yourself:
+
+  %s
+
+Either way azsel still works: run 'azsel use <name>' and source the file it
+writes. See "Use in scripts" in the README.`, which, initLine)
 }
 
 func newInitCmd() *cobra.Command {
@@ -70,9 +98,9 @@ func newInitCmd() *cobra.Command {
 				return nil
 			}
 
-			rcFile := detectShellRC()
+			rcFile, shellName := detectShellRC()
 			if rcFile == "" {
-				return fmt.Errorf("could not detect shell profile — add this manually to your shell rc:\n\n  %s", initLine)
+				return unsupportedShellError(shellName)
 			}
 
 			data, err := os.ReadFile(rcFile)

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -15,16 +15,39 @@ import (
 // acaba en .bashrc.
 func shells(t *testing.T) []string {
 	t.Helper()
+	seen := map[string]bool{}
 	var found []string
+	add := func(path string) {
+		if path == "" || seen[path] {
+			return
+		}
+		if _, err := os.Stat(path); err != nil {
+			return
+		}
+		seen[path] = true
+		found = append(found, path)
+	}
+
 	for _, name := range []string{"bash", "zsh"} {
 		if path, err := exec.LookPath(name); err == nil {
-			found = append(found, path)
+			add(path)
 		}
 	}
+	// macOS ships bash 3.2 at /bin/bash. If PATH happens to resolve to a
+	// newer one — Homebrew, or a future runner image — exercise both, so the
+	// README's claim about 3.2 stays backed by something rather than by luck.
+	add("/bin/bash")
+
 	if len(found) == 0 {
 		t.Skip("ni bash ni zsh disponibles")
 	}
 	return found
+}
+
+// shellLabel names a subtest after the interpreter's full path: two entries
+// can share a base name (/bin/bash and /opt/homebrew/bin/bash).
+func shellLabel(path string) string {
+	return strings.ReplaceAll(strings.TrimPrefix(path, "/"), "/", "_")
 }
 
 // runShellFunc evalúa la función de shell instalada por `azsel init --print`
@@ -51,10 +74,9 @@ func runShellFunc(t *testing.T, shell, home, stubBody, script string, extraEnv .
 		"PATH=" + binDir + ":" + os.Getenv("PATH"),
 		"HOME=" + home,
 	}, extraEnv...)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("%s falló: %v\nsalida:\n%s", filepath.Base(shell), err, out)
-	}
+	// El estado de salida no se comprueba aquí: hay tests que ejercitan
+	// justamente la propagación de códigos distintos de cero.
+	out, _ := cmd.CombinedOutput()
 	return string(out)
 }
 
@@ -62,7 +84,7 @@ func runShellFunc(t *testing.T, shell, home, stubBody, script string, extraEnv .
 func eachShell(t *testing.T, fn func(t *testing.T, shell string)) {
 	t.Helper()
 	for _, shell := range shells(t) {
-		t.Run(filepath.Base(shell), func(t *testing.T) { fn(t, shell) })
+		t.Run(shellLabel(shell), func(t *testing.T) { fn(t, shell) })
 	}
 }
 
@@ -222,4 +244,51 @@ func TestRootHelpUsesInitLine(t *testing.T) {
 	if strings.Contains(long, `eval "$(azsel init)"`) {
 		t.Error("la ayuda del root sigue mostrando 'azsel init' sin --print")
 	}
+}
+
+// El wrapper hacía source de lo que encontrase en su ruta, aunque la
+// invocación actual no hubiera escrito nada. Los PID se reutilizan, así que
+// un huérfano dejado por un shell muerto acababa aplicándose en un shell
+// posterior que reutilizara ese PID — el mismo fallo que #4 quería evitar,
+// por otra vía.
+func TestShellFuncIgnoresOrphanFromReusedPID(t *testing.T) {
+	eachShell(t, func(t *testing.T, shell string) {
+		home := t.TempDir()
+		// El stub no escribe nada, como haría `azsel list`.
+		out := runShellFunc(t, shell, home, "true\n",
+			`printf 'export AZURE_CONFIG_DIR=/tenant/OBSOLETO\n' > "$HOME/.azsel/.switch.$$"
+azsel list
+echo "RESULT=[${AZURE_CONFIG_DIR:-}]"`)
+
+		if !strings.Contains(out, "RESULT=[]") {
+			t.Errorf("se aplicó un switch huérfano.\nsalida:\n%s", out)
+		}
+	})
+}
+
+// El wrapper devolvía siempre 0: el `if` final se comía el estado de salida
+// del binario. `azsel use inexistente && deploy` ejecutaba deploy.
+func TestShellFuncPropagatesExitStatus(t *testing.T) {
+	eachShell(t, func(t *testing.T, shell string) {
+		home := t.TempDir()
+		out := runShellFunc(t, shell, home, "exit 7\n",
+			`azsel use inexistente; echo "STATUS=$?"`)
+
+		if !strings.Contains(out, "STATUS=7") {
+			t.Errorf("no se propagó el código de salida.\nsalida:\n%s", out)
+		}
+	})
+}
+
+// Y el caso feliz debe seguir devolviendo 0 aun habiendo sourceado.
+func TestShellFuncReturnsZeroOnSuccess(t *testing.T) {
+	eachShell(t, func(t *testing.T, shell string) {
+		home := t.TempDir()
+		stub := `printf 'export AZURE_CONFIG_DIR=%s\n' /fake/acme > "$AZSEL_SWITCH_FILE"` + "\n"
+		out := runShellFunc(t, shell, home, stub, `azsel use acme; echo "STATUS=$?"`)
+
+		if !strings.Contains(out, "STATUS=0") {
+			t.Errorf("un cambio correcto no devolvió 0.\nsalida:\n%s", out)
+		}
+	})
 }

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -207,3 +207,19 @@ func TestInitLineUsesPrint(t *testing.T) {
 		t.Errorf("initLine = %q, quería que usara --print", initLine)
 	}
 }
+
+// La ayuda del comando raíz mostraba `eval "$(azsel init)"`, sin --print. Sin
+// ese flag, init no imprime la función: modifica el fichero rc. Quien pegara
+// esa línea en su .zshrc se quedaba sin integración.
+//
+// La ayuda concatena initLine en vez de repetir el texto, así que este test
+// vigila que esa unión no se deshaga.
+func TestRootHelpUsesInitLine(t *testing.T) {
+	long := rootCmd.Long
+	if !strings.Contains(long, initLine) {
+		t.Errorf("la ayuda del root no contiene %q:\n%s", initLine, long)
+	}
+	if strings.Contains(long, `eval "$(azsel init)"`) {
+		t.Error("la ayuda del root sigue mostrando 'azsel init' sin --print")
+	}
+}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runShellFunc evalúa la función de shell instalada por `azsel init --print`
+// en un bash real, con un azsel de mentira en el PATH que escribe lo que se
+// le indique en $AZSEL_SWITCH_FILE. Devuelve la salida del script.
+//
+// Es el único test que ejercita el mecanismo central de azsel de punta a
+// punta: el binario no puede tocar el entorno del shell padre, así que todo
+// depende de que esta función haga el source correctamente.
+func runShellFunc(t *testing.T, home, stubBody, script string) string {
+	t.Helper()
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash no disponible")
+	}
+
+	binDir := t.TempDir()
+	stub := filepath.Join(binDir, "azsel")
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\n"+stubBody), 0755); err != nil {
+		t.Fatalf("escribiendo el stub: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, ".azsel"), 0755); err != nil {
+		t.Fatalf("preparando el home: %v", err)
+	}
+
+	cmd := exec.Command(bash, "-c", shellFunc+"\n"+script)
+	cmd.Env = []string{
+		"PATH=" + binDir + ":" + os.Getenv("PATH"),
+		"HOME=" + home,
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bash falló: %v\nsalida:\n%s", err, out)
+	}
+	return string(out)
+}
+
+// El caso base: azsel escribe el snippet, la función lo sourcea y la variable
+// queda puesta en el shell.
+func TestShellFuncSourcesSwitchFile(t *testing.T) {
+	home := t.TempDir()
+	stub := `printf 'export AZURE_CONFIG_DIR=%s\n' /fake/tenants/acme > "$AZSEL_SWITCH_FILE"` + "\n"
+	out := runShellFunc(t, home, stub, `azsel use acme; echo "RESULT=$AZURE_CONFIG_DIR"`)
+
+	if !strings.Contains(out, "RESULT=/fake/tenants/acme") {
+		t.Errorf("la variable no llegó al shell.\nsalida:\n%s", out)
+	}
+}
+
+// Tras sourcear, el fichero debe desaparecer: si sobreviviera, la siguiente
+// invocación lo volvería a aplicar.
+func TestShellFuncRemovesSwitchFileAfterSourcing(t *testing.T) {
+	home := t.TempDir()
+	stub := `printf 'export AZURE_CONFIG_DIR=%s\n' /fake/acme > "$AZSEL_SWITCH_FILE"` + "\n"
+	out := runShellFunc(t, home, stub,
+		`azsel use acme; ls "$HOME/.azsel/" | grep -c switch || echo "SIN_RESTOS"`)
+
+	if !strings.Contains(out, "SIN_RESTOS") {
+		t.Errorf("quedaron ficheros de switch.\nsalida:\n%s", out)
+	}
+}
+
+// El corazón de #4: cada shell usa su propia ruta, derivada de su PID. Sin
+// esto, una terminal consumía y borraba el switch pendiente de otra.
+func TestShellFuncUsesPerShellSwitchFile(t *testing.T) {
+	home := t.TempDir()
+	// El stub delata la ruta que le han pasado en vez de escribir nada.
+	stub := `echo "PATH_USADO=$AZSEL_SWITCH_FILE"` + "\n"
+
+	first := runShellFunc(t, home, stub, `azsel list`)
+	second := runShellFunc(t, home, stub, `azsel list`)
+
+	extract := func(out string) string {
+		for _, line := range strings.Split(out, "\n") {
+			if strings.HasPrefix(line, "PATH_USADO=") {
+				return strings.TrimPrefix(line, "PATH_USADO=")
+			}
+		}
+		t.Fatalf("el stub no reportó ruta.\nsalida:\n%s", out)
+		return ""
+	}
+	a, b := extract(first), extract(second)
+
+	if a == b {
+		t.Errorf("dos shells usaron la misma ruta (%s); deben diferir por PID", a)
+	}
+	for _, got := range []string{a, b} {
+		if !strings.HasPrefix(got, filepath.Join(home, ".azsel", ".switch.")) {
+			t.Errorf("ruta = %q, quería ~/.azsel/.switch.<pid>", got)
+		}
+	}
+}
+
+// AZSEL_SWITCH_FILE es para el subproceso, no para la sesión: no debe quedar
+// colgando en el entorno del usuario.
+func TestShellFuncDoesNotLeakSwitchVar(t *testing.T) {
+	home := t.TempDir()
+	stub := `true` + "\n"
+	out := runShellFunc(t, home, stub,
+		`azsel list; echo "FUGA=[${AZSEL_SWITCH_FILE:-}]"`)
+
+	if !strings.Contains(out, "FUGA=[]") {
+		t.Errorf("AZSEL_SWITCH_FILE quedó en el entorno.\nsalida:\n%s", out)
+	}
+}
+
+// La función respeta AZSEL_HOME, igual que el binario.
+func TestShellFuncHonoursAzselHome(t *testing.T) {
+	home := t.TempDir()
+	alt := t.TempDir()
+	stub := `echo "PATH_USADO=$AZSEL_SWITCH_FILE"` + "\n"
+	out := runShellFunc(t, home, stub, `export AZSEL_HOME=`+alt+`; azsel list`)
+
+	if !strings.Contains(out, "PATH_USADO="+filepath.Join(alt, ".switch.")) {
+		t.Errorf("no se respetó AZSEL_HOME.\nsalida:\n%s", out)
+	}
+}
+
+// Sin fichero de switch, la función no debe romper ni ensuciar la salida.
+func TestShellFuncWithoutSwitchFile(t *testing.T) {
+	home := t.TempDir()
+	out := runShellFunc(t, home, "true\n", `azsel list; echo "OK=$?"`)
+	if !strings.Contains(out, "OK=0") {
+		t.Errorf("la función falló sin fichero de switch.\nsalida:\n%s", out)
+	}
+}
+
+// La línea que init escribe en el rc debe invocar --print; sin él, init
+// modifica el fichero rc en vez de imprimir la función (ver #2).
+func TestInitLineUsesPrint(t *testing.T) {
+	if !strings.Contains(initLine, "--print") {
+		t.Errorf("initLine = %q, quería que usara --print", initLine)
+	}
+}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -8,19 +8,34 @@ import (
 	"testing"
 )
 
+// shells devuelve los intérpretes en los que azsel instala su función
+// (detectShellRC contempla zsh y bash), saltando los que no estén presentes.
+// La función se instala en ambos, así que debe funcionar en ambos: #3 nació
+// justo de una construcción exclusiva de zsh metida en un fichero que también
+// acaba en .bashrc.
+func shells(t *testing.T) []string {
+	t.Helper()
+	var found []string
+	for _, name := range []string{"bash", "zsh"} {
+		if path, err := exec.LookPath(name); err == nil {
+			found = append(found, path)
+		}
+	}
+	if len(found) == 0 {
+		t.Skip("ni bash ni zsh disponibles")
+	}
+	return found
+}
+
 // runShellFunc evalúa la función de shell instalada por `azsel init --print`
-// en un bash real, con un azsel de mentira en el PATH que escribe lo que se
-// le indique en $AZSEL_SWITCH_FILE. Devuelve la salida del script.
+// en un intérprete real, con un azsel de mentira en el PATH que escribe lo
+// que se le indique en $AZSEL_SWITCH_FILE. Devuelve la salida del script.
 //
 // Es el único test que ejercita el mecanismo central de azsel de punta a
 // punta: el binario no puede tocar el entorno del shell padre, así que todo
 // depende de que esta función haga el source correctamente.
-func runShellFunc(t *testing.T, home, stubBody, script string) string {
+func runShellFunc(t *testing.T, shell, home, stubBody, script string, extraEnv ...string) string {
 	t.Helper()
-	bash, err := exec.LookPath("bash")
-	if err != nil {
-		t.Skip("bash no disponible")
-	}
 
 	binDir := t.TempDir()
 	stub := filepath.Join(binDir, "azsel")
@@ -31,105 +46,157 @@ func runShellFunc(t *testing.T, home, stubBody, script string) string {
 		t.Fatalf("preparando el home: %v", err)
 	}
 
-	cmd := exec.Command(bash, "-c", shellFunc+"\n"+script)
-	cmd.Env = []string{
+	cmd := exec.Command(shell, "-c", shellFunc+"\n"+script)
+	cmd.Env = append([]string{
 		"PATH=" + binDir + ":" + os.Getenv("PATH"),
 		"HOME=" + home,
-	}
+	}, extraEnv...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("bash falló: %v\nsalida:\n%s", err, out)
+		t.Fatalf("%s falló: %v\nsalida:\n%s", filepath.Base(shell), err, out)
 	}
 	return string(out)
+}
+
+// eachShell ejecuta fn una vez por intérprete disponible, como subtest.
+func eachShell(t *testing.T, fn func(t *testing.T, shell string)) {
+	t.Helper()
+	for _, shell := range shells(t) {
+		t.Run(filepath.Base(shell), func(t *testing.T) { fn(t, shell) })
+	}
 }
 
 // El caso base: azsel escribe el snippet, la función lo sourcea y la variable
 // queda puesta en el shell.
 func TestShellFuncSourcesSwitchFile(t *testing.T) {
-	home := t.TempDir()
-	stub := `printf 'export AZURE_CONFIG_DIR=%s\n' /fake/tenants/acme > "$AZSEL_SWITCH_FILE"` + "\n"
-	out := runShellFunc(t, home, stub, `azsel use acme; echo "RESULT=$AZURE_CONFIG_DIR"`)
+	eachShell(t, func(t *testing.T, shell string) {
+		home := t.TempDir()
+		stub := `printf 'export AZURE_CONFIG_DIR=%s\n' /fake/tenants/acme > "$AZSEL_SWITCH_FILE"` + "\n"
+		out := runShellFunc(t, shell, home, stub, `azsel use acme; echo "RESULT=$AZURE_CONFIG_DIR"`)
 
-	if !strings.Contains(out, "RESULT=/fake/tenants/acme") {
-		t.Errorf("la variable no llegó al shell.\nsalida:\n%s", out)
-	}
+		if !strings.Contains(out, "RESULT=/fake/tenants/acme") {
+			t.Errorf("la variable no llegó al shell.\nsalida:\n%s", out)
+		}
+	})
 }
 
 // Tras sourcear, el fichero debe desaparecer: si sobreviviera, la siguiente
 // invocación lo volvería a aplicar.
 func TestShellFuncRemovesSwitchFileAfterSourcing(t *testing.T) {
-	home := t.TempDir()
-	stub := `printf 'export AZURE_CONFIG_DIR=%s\n' /fake/acme > "$AZSEL_SWITCH_FILE"` + "\n"
-	out := runShellFunc(t, home, stub,
-		`azsel use acme; ls "$HOME/.azsel/" | grep -c switch || echo "SIN_RESTOS"`)
+	eachShell(t, func(t *testing.T, shell string) {
+		home := t.TempDir()
+		stub := `printf 'export AZURE_CONFIG_DIR=%s\n' /fake/acme > "$AZSEL_SWITCH_FILE"` + "\n"
+		out := runShellFunc(t, shell, home, stub,
+			`azsel use acme; ls "$HOME/.azsel/" | grep -c switch || echo "SIN_RESTOS"`)
 
-	if !strings.Contains(out, "SIN_RESTOS") {
-		t.Errorf("quedaron ficheros de switch.\nsalida:\n%s", out)
-	}
+		if !strings.Contains(out, "SIN_RESTOS") {
+			t.Errorf("quedaron ficheros de switch.\nsalida:\n%s", out)
+		}
+	})
 }
 
 // El corazón de #4: cada shell usa su propia ruta, derivada de su PID. Sin
 // esto, una terminal consumía y borraba el switch pendiente de otra.
 func TestShellFuncUsesPerShellSwitchFile(t *testing.T) {
-	home := t.TempDir()
-	// El stub delata la ruta que le han pasado en vez de escribir nada.
-	stub := `echo "PATH_USADO=$AZSEL_SWITCH_FILE"` + "\n"
+	eachShell(t, func(t *testing.T, shell string) {
+		home := t.TempDir()
+		// El stub delata la ruta que le han pasado en vez de escribir nada.
+		stub := `echo "PATH_USADO=$AZSEL_SWITCH_FILE"` + "\n"
 
-	first := runShellFunc(t, home, stub, `azsel list`)
-	second := runShellFunc(t, home, stub, `azsel list`)
+		first := runShellFunc(t, shell, home, stub, `azsel list`)
+		second := runShellFunc(t, shell, home, stub, `azsel list`)
 
-	extract := func(out string) string {
-		for _, line := range strings.Split(out, "\n") {
-			if strings.HasPrefix(line, "PATH_USADO=") {
-				return strings.TrimPrefix(line, "PATH_USADO=")
+		extract := func(out string) string {
+			for _, line := range strings.Split(out, "\n") {
+				if strings.HasPrefix(line, "PATH_USADO=") {
+					return strings.TrimPrefix(line, "PATH_USADO=")
+				}
+			}
+			t.Fatalf("el stub no reportó ruta.\nsalida:\n%s", out)
+			return ""
+		}
+		a, b := extract(first), extract(second)
+
+		if a == b {
+			t.Errorf("dos shells usaron la misma ruta (%s); deben diferir por PID", a)
+		}
+		for _, got := range []string{a, b} {
+			if !strings.HasPrefix(got, filepath.Join(home, ".azsel", ".switch.")) {
+				t.Errorf("ruta = %q, quería ~/.azsel/.switch.<pid>", got)
 			}
 		}
-		t.Fatalf("el stub no reportó ruta.\nsalida:\n%s", out)
-		return ""
-	}
-	a, b := extract(first), extract(second)
-
-	if a == b {
-		t.Errorf("dos shells usaron la misma ruta (%s); deben diferir por PID", a)
-	}
-	for _, got := range []string{a, b} {
-		if !strings.HasPrefix(got, filepath.Join(home, ".azsel", ".switch.")) {
-			t.Errorf("ruta = %q, quería ~/.azsel/.switch.<pid>", got)
-		}
-	}
+	})
 }
 
 // AZSEL_SWITCH_FILE es para el subproceso, no para la sesión: no debe quedar
 // colgando en el entorno del usuario.
 func TestShellFuncDoesNotLeakSwitchVar(t *testing.T) {
-	home := t.TempDir()
-	stub := `true` + "\n"
-	out := runShellFunc(t, home, stub,
-		`azsel list; echo "FUGA=[${AZSEL_SWITCH_FILE:-}]"`)
+	eachShell(t, func(t *testing.T, shell string) {
+		home := t.TempDir()
+		out := runShellFunc(t, shell, home, "true\n",
+			`azsel list; echo "FUGA=[${AZSEL_SWITCH_FILE:-}]"`)
 
-	if !strings.Contains(out, "FUGA=[]") {
-		t.Errorf("AZSEL_SWITCH_FILE quedó en el entorno.\nsalida:\n%s", out)
-	}
+		if !strings.Contains(out, "FUGA=[]") {
+			t.Errorf("AZSEL_SWITCH_FILE quedó en el entorno.\nsalida:\n%s", out)
+		}
+	})
 }
 
 // La función respeta AZSEL_HOME, igual que el binario.
 func TestShellFuncHonoursAzselHome(t *testing.T) {
-	home := t.TempDir()
-	alt := t.TempDir()
-	stub := `echo "PATH_USADO=$AZSEL_SWITCH_FILE"` + "\n"
-	out := runShellFunc(t, home, stub, `export AZSEL_HOME=`+alt+`; azsel list`)
+	eachShell(t, func(t *testing.T, shell string) {
+		home := t.TempDir()
+		alt := t.TempDir()
+		stub := `echo "PATH_USADO=$AZSEL_SWITCH_FILE"` + "\n"
+		out := runShellFunc(t, shell, home, stub, `export AZSEL_HOME=`+alt+`; azsel list`)
 
-	if !strings.Contains(out, "PATH_USADO="+filepath.Join(alt, ".switch.")) {
-		t.Errorf("no se respetó AZSEL_HOME.\nsalida:\n%s", out)
-	}
+		if !strings.Contains(out, "PATH_USADO="+filepath.Join(alt, ".switch.")) {
+			t.Errorf("no se respetó AZSEL_HOME.\nsalida:\n%s", out)
+		}
+	})
 }
 
 // Sin fichero de switch, la función no debe romper ni ensuciar la salida.
 func TestShellFuncWithoutSwitchFile(t *testing.T) {
-	home := t.TempDir()
-	out := runShellFunc(t, home, "true\n", `azsel list; echo "OK=$?"`)
-	if !strings.Contains(out, "OK=0") {
-		t.Errorf("la función falló sin fichero de switch.\nsalida:\n%s", out)
+	eachShell(t, func(t *testing.T, shell string) {
+		home := t.TempDir()
+		out := runShellFunc(t, shell, home, "true\n", `azsel list; echo "OK=$?"`)
+		if !strings.Contains(out, "OK=0") {
+			t.Errorf("la función falló sin fichero de switch.\nsalida:\n%s", out)
+		}
+	})
+}
+
+// #3: el modo depuración debe funcionar en los dos shells. La función usaba
+// `whence -p`, un builtin exclusivo de zsh, y en bash imprimía
+// «whence: command not found» dentro de la propia traza de depuración.
+func TestShellFuncDebugIsPortable(t *testing.T) {
+	eachShell(t, func(t *testing.T, shell string) {
+		home := t.TempDir()
+		stub := `printf 'export AZURE_CONFIG_DIR=%s\n' /fake/acme > "$AZSEL_SWITCH_FILE"` + "\n"
+		out := runShellFunc(t, shell, home, stub, `azsel use acme`, "AZSEL_DEBUG=1")
+
+		for _, bad := range []string{"command not found", "not found", "whence"} {
+			if strings.Contains(out, bad) {
+				t.Errorf("la traza de depuración contiene %q.\nsalida:\n%s", bad, out)
+			}
+		}
+		// Y debe seguir siendo útil.
+		for _, want := range []string{"args: use acme", "switch file:", "sourcing"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("la traza no menciona %q.\nsalida:\n%s", want, out)
+			}
+		}
+	})
+}
+
+// La función generada no debe contener construcciones exclusivas de zsh: se
+// instala también en .bashrc.
+func TestShellFuncHasNoZshOnlyBuiltins(t *testing.T) {
+	for _, bad := range []string{"whence", "typeset", "setopt", "print -"} {
+		if strings.Contains(shellFunc, bad) {
+			t.Errorf("la función usa %q, que no existe en bash", bad)
+		}
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,9 +17,10 @@ each tenant's az CLI config via AZURE_CONFIG_DIR.
 
 Run without subcommands to launch the interactive TUI.
 
-Shell integration (add to .bashrc / .zshrc):
+Shell integration — run 'azsel init' to set it up automatically, or add
+this line to .bashrc / .zshrc yourself:
 
-  eval "$(azsel init)"`,
+  ` + initLine,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE:          runTUI,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,6 +35,15 @@ func init() {
 
 func Execute() error {
 	rootCmd.Version = Version
+	// The wrapper used to resolve this with `whence -p`, which only exists in
+	// zsh, and the wrapper is installed into bash too. os.Executable is both
+	// portable and more truthful: it reports the binary actually running, not
+	// what PATH says should run.
+	if os.Getenv("AZSEL_DEBUG") != "" {
+		if exe, err := os.Executable(); err == nil {
+			fmt.Fprintf(os.Stderr, "[azsel-debug-go] binary: %s\n", exe)
+		}
+	}
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		return err

--- a/cmd/shell_detect_test.go
+++ b/cmd/shell_detect_test.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDetectShellRC(t *testing.T) {
+	cases := []struct {
+		name       string
+		shell      string
+		makeBashrc bool
+		wantRC     string // relativo al home; "" = no soportado
+		wantShell  string
+	}{
+		{"zsh", "/bin/zsh", false, ".zshrc", "zsh"},
+		{"zsh en otra ruta", "/opt/homebrew/bin/zsh", false, ".zshrc", "zsh"},
+		{"bash con bashrc", "/bin/bash", true, ".bashrc", "bash"},
+		{"bash sin bashrc", "/bin/bash", false, ".bash_profile", "bash"},
+		{"fish", "/opt/homebrew/bin/fish", false, "", "fish"},
+		{"sh", "/bin/sh", false, "", "sh"},
+		{"SHELL vacío", "", false, "", ""},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("SHELL", c.shell)
+			if c.makeBashrc {
+				if err := os.WriteFile(filepath.Join(home, ".bashrc"), nil, 0644); err != nil {
+					t.Fatalf("preparando: %v", err)
+				}
+			}
+
+			rc, shell := detectShellRC()
+			want := ""
+			if c.wantRC != "" {
+				want = filepath.Join(home, c.wantRC)
+			}
+			if rc != want {
+				t.Errorf("rcFile = %q, quería %q", rc, want)
+			}
+			if shell != c.wantShell {
+				t.Errorf("shellName = %q, quería %q", shell, c.wantShell)
+			}
+		})
+	}
+}
+
+// El mensaje anterior decía "add this manually to your shell rc", lo cual es
+// falso para fish: la función usa sintaxis bash/zsh que fish no interpreta.
+func TestUnsupportedShellErrorIsHonest(t *testing.T) {
+	got := unsupportedShellError("fish").Error()
+
+	if !strings.Contains(got, "fish") {
+		t.Errorf("el error no nombra el shell detectado:\n%s", got)
+	}
+	if !strings.Contains(got, "bash and zsh") {
+		t.Errorf("el error no dice qué shells sí están soportados:\n%s", got)
+	}
+	// Debe ofrecer la salida que sí funciona en cualquier shell.
+	if !strings.Contains(got, "azsel use") {
+		t.Errorf("el error no menciona la alternativa vía script:\n%s", got)
+	}
+}
+
+func TestUnsupportedShellErrorWithoutShellEnv(t *testing.T) {
+	got := unsupportedShellError("").Error()
+	if !strings.Contains(got, "$SHELL") {
+		t.Errorf("sin SHELL definido, el error debería mencionarlo:\n%s", got)
+	}
+}

--- a/cmd/shell_detect_test.go
+++ b/cmd/shell_detect_test.go
@@ -35,7 +35,10 @@ func TestDetectShellRC(t *testing.T) {
 				}
 			}
 
-			rc, shell := detectShellRC()
+			rc, shell, err := detectShellRC()
+			if err != nil {
+				t.Fatalf("detectShellRC: %v", err)
+			}
 			want := ""
 			if c.wantRC != "" {
 				want = filepath.Join(home, c.wantRC)
@@ -71,5 +74,24 @@ func TestUnsupportedShellErrorWithoutShellEnv(t *testing.T) {
 	got := unsupportedShellError("").Error()
 	if !strings.Contains(got, "$SHELL") {
 		t.Errorf("sin SHELL definido, el error debería mencionarlo:\n%s", got)
+	}
+}
+
+// Un fallo al resolver el home es su propio problema, no un shell no
+// soportado. Antes se reportaba como lo segundo, de modo que a un usuario de
+// zsh se le decía que zsh no está soportado.
+func TestDetectShellRCSeparatesHomeFailure(t *testing.T) {
+	t.Setenv("SHELL", "/bin/zsh")
+	t.Setenv("HOME", "")
+
+	rc, shell, err := detectShellRC()
+	if err == nil {
+		t.Fatal("detectShellRC devolvió nil sin HOME")
+	}
+	if !strings.Contains(err.Error(), "home directory") {
+		t.Errorf("error = %q, quería que mencionara el home", err)
+	}
+	if rc != "" || shell != "" {
+		t.Errorf("rcFile=%q shellName=%q, quería ambos vacíos ante un error", rc, shell)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -162,6 +162,12 @@ func WriteEnv(lines string) error {
 	if err := os.WriteFile(path, []byte(lines), 0600); err != nil {
 		return err
 	}
+	// WriteFile only applies perm when it creates the file. Without this, a
+	// legacy ~/.azsel/.switch written 0644 by an older version keeps those
+	// permissions forever — and that is still the path the fallback uses.
+	if err := os.Chmod(path, 0600); err != nil {
+		return err
+	}
 	pruneStaleSwitchFiles()
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,12 +6,24 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // EnvHome overrides where azsel keeps its own state. It exists for the same
 // reason azsel exists at all: az honours AZURE_CONFIG_DIR, so azsel honours
 // AZSEL_HOME. Tests rely on it to stay away from the real ~/.azsel.
 const EnvHome = "AZSEL_HOME"
+
+// EnvSwitchFile names the file azsel writes its export snippet to. The shell
+// wrapper points it at a per-shell path so two terminals switching tenants at
+// the same time cannot consume each other's snippet.
+const EnvSwitchFile = "AZSEL_SWITCH_FILE"
+
+// staleSwitchAge is how long an orphaned switch file must sit before it is
+// swept. Orphans only appear when a shell dies between azsel writing the file
+// and the wrapper sourcing it — a window of milliseconds — so anything this
+// old is certainly abandoned.
+const staleSwitchAge = 24 * time.Hour
 
 type Tenant struct {
 	Name      string `json:"name"`
@@ -83,9 +95,19 @@ func ensureDir(path string) (created bool, err error) {
 }
 
 func ConfigPath() (string, error)    { return inBase("config.json") }
-func EnvFile() (string, error)       { return inBase(".switch") }
 func ExtensionsDir() (string, error) { return inBase("extensions") }
 func TenantsDir() (string, error)    { return inBase("tenants") }
+
+// EnvFile reports where the export snippet goes. The shell wrapper sets
+// EnvSwitchFile to a path carrying its own PID; the fallback keeps wrappers
+// installed before that change — and the documented scripting pattern —
+// working.
+func EnvFile() (string, error) {
+	if path := os.Getenv(EnvSwitchFile); path != "" {
+		return path, nil
+	}
+	return inBase(".switch")
+}
 
 // TenantDir computes a tenant's config directory without creating it.
 func TenantDir(name string) (string, error) {
@@ -125,17 +147,50 @@ func EnsureTenantDir(name string) (dir string, created bool, err error) {
 }
 
 func WriteEnv(lines string) error {
-	if _, err := EnsureBaseDir(); err != nil {
-		return err
-	}
 	path, err := EnvFile()
 	if err != nil {
 		return err
 	}
+	dir := filepath.Dir(path)
+	if _, err := ensureDir(dir); err != nil {
+		return fmt.Errorf("creating %s: %w", dir, err)
+	}
 	if os.Getenv("AZSEL_DEBUG") != "" {
 		fmt.Fprintf(os.Stderr, "[azsel-debug-go] writing %s\n", path)
 	}
-	return os.WriteFile(path, []byte(lines), 0644)
+	// 0600: the shell sources this file, so its contents run as the user.
+	if err := os.WriteFile(path, []byte(lines), 0600); err != nil {
+		return err
+	}
+	pruneStaleSwitchFiles()
+	return nil
+}
+
+// pruneStaleSwitchFiles sweeps switch files left behind by shells that died
+// before sourcing theirs. Best effort: a failure here must never make a
+// tenant switch fail. The legacy ~/.azsel/.switch is left alone — a wrapper
+// installed before EnvSwitchFile existed may be about to source it.
+func pruneStaleSwitchFiles() {
+	base, err := BaseDir()
+	if err != nil {
+		return
+	}
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasPrefix(e.Name(), ".switch.") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if time.Since(info.ModTime()) > staleSwitchAge {
+			os.Remove(filepath.Join(base, e.Name()))
+		}
+	}
 }
 
 func Load() (*Config, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -327,9 +327,10 @@ func TestWriteEnv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat: %v", err)
 	}
-	// Documenta el comportamiento actual; #4 valora bajarlo a 0600.
-	if perm := fi.Mode().Perm(); perm != 0644 {
-		t.Errorf("permisos = %04o, quería 0644", perm)
+	// 0600 desde #4: el shell hace source de este fichero, así que su
+	// contenido se ejecuta con los permisos del usuario.
+	if perm := fi.Mode().Perm(); perm != 0600 {
+		t.Errorf("permisos = %04o, quería 0600", perm)
 	}
 }
 

--- a/internal/config/switch_test.go
+++ b/internal/config/switch_test.go
@@ -1,0 +1,148 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aolmosj/azsel/internal/config"
+)
+
+func TestEnvFileHonoursSwitchFileVar(t *testing.T) {
+	sandbox(t)
+	want := filepath.Join(t.TempDir(), ".switch.4242")
+	t.Setenv(config.EnvSwitchFile, want)
+
+	got, err := config.EnvFile()
+	if err != nil {
+		t.Fatalf("EnvFile: %v", err)
+	}
+	if got != want {
+		t.Errorf("EnvFile = %q, quería %q", got, want)
+	}
+}
+
+// El fallback mantiene funcionando a los wrappers instalados antes de #4 y al
+// patrón de scripts documentado en el README.
+func TestEnvFileFallsBackToLegacyPath(t *testing.T) {
+	dir := sandbox(t)
+	t.Setenv(config.EnvSwitchFile, "")
+
+	got, err := config.EnvFile()
+	if err != nil {
+		t.Fatalf("EnvFile: %v", err)
+	}
+	if want := filepath.Join(dir, ".switch"); got != want {
+		t.Errorf("EnvFile = %q, quería %q", got, want)
+	}
+}
+
+func TestWriteEnvUsesSwitchFileVar(t *testing.T) {
+	base := sandbox(t)
+	target := filepath.Join(t.TempDir(), "sub", ".switch.99")
+	t.Setenv(config.EnvSwitchFile, target)
+
+	const lines = "export AZURE_CONFIG_DIR=/fake/acme\n"
+	if err := config.WriteEnv(lines); err != nil {
+		t.Fatalf("WriteEnv: %v", err)
+	}
+
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("leyendo el destino: %v", err)
+	}
+	if string(data) != lines {
+		t.Errorf("contenido = %q, quería %q", data, lines)
+	}
+	// No debe escribir además en la ruta antigua.
+	if _, err := os.Stat(filepath.Join(base, ".switch")); !os.IsNotExist(err) {
+		t.Error("WriteEnv escribió también en el .switch heredado")
+	}
+}
+
+// El escenario que motiva #4: dos shells cambiando de tenant a la vez. Antes
+// compartían fichero, así que una consumía el switch de la otra.
+func TestConcurrentShellsDoNotShareSwitchFile(t *testing.T) {
+	base := sandbox(t)
+
+	write := func(pid, tenant string) string {
+		path := filepath.Join(base, ".switch."+pid)
+		t.Setenv(config.EnvSwitchFile, path)
+		if err := config.WriteEnv("export AZURE_CONFIG_DIR=/fake/" + tenant + "\n"); err != nil {
+			t.Fatalf("WriteEnv(%s): %v", pid, err)
+		}
+		return path
+	}
+
+	// La shell A escribe su switch y todavía no lo ha sourceado.
+	pathA := write("1001", "acme")
+	// La shell B ejecuta azsel entretanto.
+	pathB := write("1002", "globex")
+
+	for _, c := range []struct{ path, want string }{
+		{pathA, "/fake/acme"},
+		{pathB, "/fake/globex"},
+	} {
+		data, err := os.ReadFile(c.path)
+		if err != nil {
+			t.Fatalf("leyendo %s: %v", c.path, err)
+		}
+		if got := string(data); got != "export AZURE_CONFIG_DIR="+c.want+"\n" {
+			t.Errorf("%s contiene %q, quería %s", c.path, got, c.want)
+		}
+	}
+}
+
+func TestWriteEnvPrunesStaleSwitchFiles(t *testing.T) {
+	base := sandbox(t)
+	if _, err := config.EnsureBaseDir(); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+
+	stale := filepath.Join(base, ".switch.1234")
+	fresh := filepath.Join(base, ".switch.5678")
+	legacy := filepath.Join(base, ".switch")
+	for _, p := range []string{stale, fresh, legacy} {
+		if err := os.WriteFile(p, []byte("export FOO=bar\n"), 0600); err != nil {
+			t.Fatalf("preparando %s: %v", p, err)
+		}
+	}
+	old := time.Now().Add(-48 * time.Hour)
+	for _, p := range []string{stale, legacy} {
+		if err := os.Chtimes(p, old, old); err != nil {
+			t.Fatalf("envejeciendo %s: %v", p, err)
+		}
+	}
+
+	t.Setenv(config.EnvSwitchFile, filepath.Join(base, ".switch.9999"))
+	if err := config.WriteEnv("export AZURE_CONFIG_DIR=/fake/acme\n"); err != nil {
+		t.Fatalf("WriteEnv: %v", err)
+	}
+
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Error("no se podó el fichero de switch huérfano")
+	}
+	if _, err := os.Stat(fresh); err != nil {
+		t.Error("se podó un fichero de switch reciente")
+	}
+	// El .switch heredado se respeta: un wrapper antiguo puede estar a punto
+	// de sourcearlo.
+	if _, err := os.Stat(legacy); err != nil {
+		t.Error("se podó el .switch heredado")
+	}
+}
+
+// La poda es best-effort: si falla, el cambio de tenant no debe fallar.
+func TestWriteEnvSucceedsWhenPruneCannotRead(t *testing.T) {
+	target := filepath.Join(t.TempDir(), ".switch.1")
+	t.Setenv(config.EnvHome, filepath.Join(t.TempDir(), "no", "existe"))
+	t.Setenv(config.EnvSwitchFile, target)
+
+	if err := config.WriteEnv("export AZURE_CONFIG_DIR=/fake/acme\n"); err != nil {
+		t.Fatalf("WriteEnv: %v", err)
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Fatalf("no se escribió el switch: %v", err)
+	}
+}


### PR DESCRIPTION
Second batch of Phase 1 (#13): the contract between the binary and the shell function, the messages that explain it, and what is actually supported.

## Scope

- [x] #4 — The `.switch` file is global: race between concurrent shells
- [x] #3 — The shell function uses `whence -p` (zsh only) but installs into bash
- [x] #2 — The root help shows `eval "$(azsel init)"` without `--print`
- [x] #1 — `add` suggests `eval $(azsel use X)`, which has no effect
- [x] #18 — Compatibility matrix

## #4 — Per-shell switch file

The binary and the wrapper talked over a shared path, and the wrapper `source`d whatever it found after **any** `azsel` command. Two terminals were enough: A runs `azsel use acme` and writes the switch; B runs `azsel list` before A consumes it, sources it **and deletes it**. B ends up in a tenant it never asked for and A doesn't switch.

The wrapper now points `AZSEL_SWITCH_FILE` at a path carrying its own PID. With the variable undefined the old path is used, so wrappers already installed keep working.

**Deviation from the plan:** the issue proposed `${TMPDIR:-/tmp}`. The file lives under `~/.azsel`. The wrapper `source`s it, i.e. **runs its contents in the interactive shell**; on a multi-user Linux box `/tmp` is world-writable and the name would be predictable, so another user could pre-create the path and inject code. `~/.azsel` isn't writable by anyone else. The trade-off is losing `/tmp`'s cleanup, so orphans older than a day are pruned. `0600` permissions for the same reason.

## #3 — `whence -p` doesn't exist in bash

`command -v` didn't work: inside the `azsel` function it resolves to the function, not the binary. Go reports it now via `os.Executable()`, which also tells you which binary *actually* runs rather than what `PATH` promises. Traces separated by origin: `[azsel-debug]` from the shell, `[azsel-debug-go]` from the binary.

## #2 — The root help

Without `--print`, `init` doesn't print the function: it edits the rc file. The help **concatenates `initLine`** instead of repeating the text, so the two can't diverge again.

## #1 — The `add` message

`eval $(azsel use X)` does nothing: `use` doesn't write to stdout, so the substitution captures the empty string. Anyone with the integration saw it work anyway — their wrapper sourced the file — which made the wrong advice look correct.

Detecting whether the integration is active came **for free from #4**: the wrapper defines `AZSEL_SWITCH_FILE` when invoking the binary, so its absence means there's no wrapper. The issue proposed inventing a marker variable; that wasn't needed.

## #18 — Compatibility matrix

Writing it surfaced two real defects:

**Go 1.22 vs 1.24.13.** The README asked for `Go 1.22+`; `go.mod` declares `1.24.13`. Building with 1.22 fails. The README now points at `go.mod` instead of repeating a number that drifts out of sync. Lowering the floor is a separate compatibility decision, not something to decide by writing documentation.

**The fish advice was false.** `azsel init` said *"add this manually to your shell rc"* and offered the line — but the wrapper uses `local`, `[[ ]]` and `source`, which fish doesn't interpret. The message now names the detected shell, says which ones are actually supported, offers the line only where it can work, and points at the scripting path that works in any shell.

**CI backs the matrix.** Claiming "bash and zsh supported" was worth nothing while the tests silently skipped the missing interpreter, and `go test` in CI isn't verbose, so a skip was invisible. The Linux job installs zsh and both print their versions:

| | bash | zsh |
|---|---|---|
| Ubuntu | 5.2.21 | 5.9 |
| macOS | 3.2.57 | 5.9 |

That also confirms what the README claims about bash 3.2, the one macOS still ships.

Architecture deliberately out: the releases already list the binaries.

## Tests

The first to exercise the mechanism azsel rests on end-to-end, running the generated function under real bash and zsh with a fake `azsel` on `PATH`. I verified they have teeth: reintroducing the `whence -p`, `TestShellFuncDebugIsPortable` fails **only under bash**, which is exactly the shape of the bug.

---

Closes #4
Closes #3
Closes #2
Closes #1
Closes #18