### PR TITLE
Phase 1 · Batch 3 — add flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ This installs a shell wrapper that makes `azsel` and `azsel use <name>` automati
 ```bash
 $ azsel add
 Tenant name (lowercase, alphanumeric, hyphens): contoso
-Azure Tenant ID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+Azure Tenant ID (GUID or domain): xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 
 Logging in to tenant "contoso" (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)...
 # Browser opens for Azure login...
@@ -134,6 +134,8 @@ To activate: azsel use contoso
 ```
 
 If shell integration is not set up, `azsel add` says so rather than leaving you to find out when `azsel use` appears to do nothing.
+
+The tenant can be given as a GUID or as one of the tenant's verified domains, such as `contoso.onmicrosoft.com` — `az login --tenant` accepts both. Anything else is rejected before the browser opens.
 
 Use `--device-code` to authenticate via device code flow instead of opening a browser (useful for remote/headless machines):
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -53,7 +53,7 @@ func newAddCmd() *cobra.Command {
 				return fmt.Errorf("tenant ID cannot be empty")
 			}
 
-			configDir, _, err := config.EnsureTenantDir(name)
+			configDir, createdDir, err := config.EnsureTenantDir(name)
 			if err != nil {
 				return err
 			}
@@ -65,6 +65,15 @@ func newAddCmd() *cobra.Command {
 
 			fmt.Fprintf(os.Stderr, "\nLogging in to tenant %q (%s)...\n", name, tenantID)
 			if err := azure.Login(tenantID, configDir, extDir, useDeviceCode); err != nil {
+				// Undo only what this run created. A directory that was
+				// already there can hold valid credentials from an earlier
+				// attempt, and deleting those would turn a failed login into
+				// a lost session.
+				if createdDir {
+					if rmErr := os.RemoveAll(configDir); rmErr != nil {
+						fmt.Fprintf(os.Stderr, "Warning: could not remove %s: %v\n", configDir, rmErr)
+					}
+				}
 				return fmt.Errorf("az login failed: %w", err)
 			}
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -22,6 +22,13 @@ func newAddCmd() *cobra.Command {
 		Short: "Add a new Azure tenant",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Before anything the user would have to undo. Everything below
+			// this line either asks them for input or creates directories,
+			// and all of it is wasted if az is not installed.
+			if err := azure.Available(); err != nil {
+				return err
+			}
+
 			cfg, err := config.Load()
 			if err != nil {
 				return err

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -14,6 +14,37 @@ import (
 
 var nameRegex = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
 
+// az login --tenant takes either a tenant GUID or one of the tenant's
+// verified domains, so accepting only GUIDs would reject a legitimate case.
+var (
+	tenantGUIDRegex = regexp.MustCompile(
+		`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+	// Two or more dot-separated labels; a label is alphanumeric and may
+	// contain inner hyphens.
+	tenantDomainRegex = regexp.MustCompile(
+		`^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)+$`)
+)
+
+// normalizeTenantID checks the tenant ID and returns it canonicalised.
+//
+// Only the shape is checked — whether the tenant exists is az's business.
+// The point is to fail on an obvious typo before the browser opens, with a
+// message better than whatever Azure returns.
+func normalizeTenantID(raw string) (string, error) {
+	id := strings.TrimSpace(raw)
+	if id == "" {
+		return "", fmt.Errorf("tenant ID cannot be empty")
+	}
+	// Both forms are case-insensitive; storing one casing keeps config.json
+	// and the ACTIVE column of `azsel list` comparable.
+	if tenantGUIDRegex.MatchString(id) || tenantDomainRegex.MatchString(id) {
+		return strings.ToLower(id), nil
+	}
+	return "", fmt.Errorf("invalid tenant ID %q — expected a GUID such as "+
+		"11111111-1111-1111-1111-111111111111, or a domain such as "+
+		"contoso.onmicrosoft.com", id)
+}
+
 func newAddCmd() *cobra.Command {
 	var useDeviceCode bool
 
@@ -46,11 +77,11 @@ func newAddCmd() *cobra.Command {
 				return fmt.Errorf("tenant %q already exists", name)
 			}
 
-			fmt.Fprint(os.Stderr, "Azure Tenant ID: ")
-			tenantID, _ := reader.ReadString('\n')
-			tenantID = strings.TrimSpace(tenantID)
-			if tenantID == "" {
-				return fmt.Errorf("tenant ID cannot be empty")
+			fmt.Fprint(os.Stderr, "Azure Tenant ID (GUID or domain): ")
+			rawTenantID, _ := reader.ReadString('\n')
+			tenantID, err := normalizeTenantID(rawTenantID)
+			if err != nil {
+				return err
 			}
 
 			configDir, createdDir, err := config.EnsureTenantDir(name)

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -35,8 +35,10 @@ func normalizeTenantID(raw string) (string, error) {
 	if id == "" {
 		return "", fmt.Errorf("tenant ID cannot be empty")
 	}
-	// Both forms are case-insensitive; storing one casing keeps config.json
-	// and the ACTIVE column of `azsel list` comparable.
+	// Both forms are case-insensitive to Azure, so the casing carries no
+	// meaning. Storing one keeps what `azsel list` and the TUI display
+	// consistent. Nothing depends on it: list marks the active tenant by
+	// comparing ConfigDir, and the TUI filter already ignores case.
 	if tenantGUIDRegex.MatchString(id) || tenantDomainRegex.MatchString(id) {
 		return strings.ToLower(id), nil
 	}
@@ -89,6 +91,25 @@ func newAddCmd() *cobra.Command {
 				return err
 			}
 
+			// From here on the tenant directory may exist without a config
+			// entry to match, so every exit has to undo it. A deferred
+			// rollback covers the paths a hand-written one keeps missing:
+			// the login, but also a failing extensions directory or a
+			// config.json that cannot be written.
+			//
+			// Only what this run created. A directory that was already there
+			// can hold valid credentials from an earlier attempt, and
+			// deleting those would turn a failed add into a lost session.
+			added := false
+			defer func() {
+				if added || !createdDir {
+					return
+				}
+				if rmErr := os.RemoveAll(configDir); rmErr != nil {
+					fmt.Fprintf(os.Stderr, "Warning: could not remove %s: %v\n", configDir, rmErr)
+				}
+			}()
+
 			extDir, err := config.EnsureExtensionsDir()
 			if err != nil {
 				return err
@@ -96,15 +117,6 @@ func newAddCmd() *cobra.Command {
 
 			fmt.Fprintf(os.Stderr, "\nLogging in to tenant %q (%s)...\n", name, tenantID)
 			if err := azure.Login(tenantID, configDir, extDir, useDeviceCode); err != nil {
-				// Undo only what this run created. A directory that was
-				// already there can hold valid credentials from an earlier
-				// attempt, and deleting those would turn a failed login into
-				// a lost session.
-				if createdDir {
-					if rmErr := os.RemoveAll(configDir); rmErr != nil {
-						fmt.Fprintf(os.Stderr, "Warning: could not remove %s: %v\n", configDir, rmErr)
-					}
-				}
 				return fmt.Errorf("az login failed: %w", err)
 			}
 
@@ -116,6 +128,7 @@ func newAddCmd() *cobra.Command {
 			if err := cfg.AddTenant(tenant); err != nil {
 				return err
 			}
+			added = true
 
 			fmt.Fprintf(os.Stderr, "\nTenant %q added successfully.\n", name)
 			fmt.Fprint(os.Stderr, activationHint(name, shellIntegrationInstalled()))

--- a/cmd/add_rollback_test.go
+++ b/cmd/add_rollback_test.go
@@ -125,3 +125,50 @@ func TestAddRejectsInvalidNameWithoutTouchingDisk(t *testing.T) {
 		t.Errorf("se pidió el tenant ID pese al nombre inválido:\n%s", got)
 	}
 }
+
+// Un tenant ID mal pegado debe morir aquí, no en Azure: el error de azsel es
+// más claro y no cuesta un viaje al navegador.
+func TestAddRejectsInvalidTenantIDBeforeCallingAz(t *testing.T) {
+	home := addSandbox(t)
+	fakeAzureCLI(t, `touch "$AZSEL_HOME/az-called"; exit 0`)
+	feedStdin(t, "acme\nno-soy-un-tenant\n")
+	quiet(t)
+
+	err := run(t, newAddCmd())
+	if err == nil {
+		t.Fatal("add aceptó un tenant ID inválido")
+	}
+	if !strings.Contains(err.Error(), "invalid tenant ID") {
+		t.Errorf("error = %q, quería que explicara el formato", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, "az-called")); !os.IsNotExist(err) {
+		t.Error("se invocó az pese al tenant ID inválido")
+	}
+	if _, err := os.Stat(filepath.Join(home, "tenants", "acme")); !os.IsNotExist(err) {
+		t.Error("se creó el directorio del tenant pese al tenant ID inválido")
+	}
+}
+
+// La normalización tiene que llegar hasta config.json: si no, el mismo tenant
+// escrito con distinta caja aparecería como dos entradas distintas.
+func TestAddStoresTenantIDNormalized(t *testing.T) {
+	addSandbox(t)
+	fakeAzureCLI(t, "exit 0")
+	feedStdin(t, "acme\nAABBCCDD-1122-3344-5566-778899AABBCC\n")
+	quiet(t)
+
+	if err := run(t, newAddCmd()); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	tenant := cfg.FindTenant("acme")
+	if tenant == nil {
+		t.Fatal("no se guardó el tenant")
+	}
+	if want := "aabbccdd-1122-3344-5566-778899aabbcc"; tenant.TenantID != want {
+		t.Errorf("TenantID = %q, quería %q", tenant.TenantID, want)
+	}
+}

--- a/cmd/add_rollback_test.go
+++ b/cmd/add_rollback_test.go
@@ -172,3 +172,60 @@ func TestAddStoresTenantIDNormalized(t *testing.T) {
 		t.Errorf("TenantID = %q, quería %q", tenant.TenantID, want)
 	}
 }
+
+// El rollback no puede cubrir solo el login. Entre crear el directorio del
+// tenant y escribir config.json hay más formas de salir, y todas dejan el
+// mismo huérfano. Esta reproduce una real: un fichero ocupando la ruta del
+// directorio de extensiones, que EnsureExtensionsDir rechaza desde #7.
+func TestAddRemovesDirectoryWhenExtensionsDirFails(t *testing.T) {
+	home := addSandbox(t)
+	if err := os.WriteFile(filepath.Join(home, "extensions"), nil, 0644); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	fakeAzureCLI(t, "exit 0")
+	feedStdin(t, "acme\n"+testTenantID+"\n")
+	quiet(t)
+
+	if err := run(t, newAddCmd()); err == nil {
+		t.Fatal("add devolvió nil con el directorio de extensiones bloqueado")
+	}
+	if _, err := os.Stat(filepath.Join(home, "tenants", "acme")); !os.IsNotExist(err) {
+		t.Errorf("quedó el directorio huérfano (err=%v)", err)
+	}
+}
+
+// Y tampoco puede dejarlo si falla el guardado de config.json: un tenant con
+// directorio pero sin entrada es exactamente el estado que #9 elimina.
+//
+// Llegar hasta el Save requiere cuidado. Poner un directorio en la ruta de
+// config.json no vale: Load falla al arrancar el comando, antes de que se
+// cree nada, y el test pasaría sin haber ejercitado nada. Lo que se hace es
+// dejar tenants/ y extensions/ ya creados y volver ~/.azsel de solo lectura,
+// de modo que todo tenga éxito hasta la escritura final.
+func TestAddRemovesDirectoryWhenConfigCannotBeSaved(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignora los permisos de fichero")
+	}
+	home := addSandbox(t)
+	for _, dir := range []string{"tenants", "extensions"} {
+		if err := os.MkdirAll(filepath.Join(home, dir), 0755); err != nil {
+			t.Fatalf("preparando: %v", err)
+		}
+	}
+	if err := os.Chmod(home, 0555); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	// Devolver el permiso de escritura para que t.TempDir pueda limpiar.
+	t.Cleanup(func() { os.Chmod(home, 0755) })
+
+	fakeAzureCLI(t, "exit 0")
+	feedStdin(t, "acme\n"+testTenantID+"\n")
+	quiet(t)
+
+	if err := run(t, newAddCmd()); err == nil {
+		t.Fatal("add devolvió nil sin poder guardar la configuración")
+	}
+	if _, err := os.Stat(filepath.Join(home, "tenants", "acme")); !os.IsNotExist(err) {
+		t.Errorf("quedó el directorio huérfano (err=%v)", err)
+	}
+}

--- a/cmd/add_rollback_test.go
+++ b/cmd/add_rollback_test.go
@@ -1,0 +1,127 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aolmosj/azsel/internal/config"
+)
+
+const testTenantID = "11111111-1111-1111-1111-111111111111"
+
+// sandbox aísla la configuración de azsel para un test.
+func addSandbox(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv(config.EnvHome, home)
+	return home
+}
+
+// El caso feliz, de punta a punta con un az de mentira que sale con 0.
+func TestAddSucceeds(t *testing.T) {
+	home := addSandbox(t)
+	fakeAzureCLI(t, "exit 0")
+	feedStdin(t, "acme\n"+testTenantID+"\n")
+	quiet(t)
+
+	if err := run(t, newAddCmd()); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	if fi, err := os.Stat(filepath.Join(home, "tenants", "acme")); err != nil || !fi.IsDir() {
+		t.Fatalf("no se creó el directorio del tenant: %v", err)
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got := cfg.FindTenant("acme")
+	if got == nil {
+		t.Fatal("el tenant no se guardó en config.json")
+	}
+	if got.TenantID != testTenantID {
+		t.Errorf("TenantID = %q, quería %q", got.TenantID, testTenantID)
+	}
+}
+
+// El fallo que motiva esta issue: az login falla y el directorio se queda.
+func TestAddRemovesDirectoryItCreatedWhenLoginFails(t *testing.T) {
+	home := addSandbox(t)
+	fakeAzureCLI(t, "exit 1")
+	feedStdin(t, "acme\n"+testTenantID+"\n")
+	quiet(t)
+
+	if err := run(t, newAddCmd()); err == nil {
+		t.Fatal("add devolvió nil con az login fallando")
+	}
+
+	if _, err := os.Stat(filepath.Join(home, "tenants", "acme")); !os.IsNotExist(err) {
+		t.Errorf("quedó el directorio huérfano (err=%v)", err)
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.FindTenant("acme") != nil {
+		t.Error("config.json quedó con un tenant cuyo login no completó")
+	}
+}
+
+// El contrapunto, y lo que hace peligroso este arreglo si se hace mal: un
+// directorio preexistente puede contener credenciales válidas de un intento
+// anterior. Un login fallido no debe destruirlas.
+func TestAddKeepsPreexistingDirectoryWhenLoginFails(t *testing.T) {
+	home := addSandbox(t)
+
+	tenantDir := filepath.Join(home, "tenants", "acme")
+	if err := os.MkdirAll(tenantDir, 0755); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	token := filepath.Join(tenantDir, "msal_token_cache.json")
+	if err := os.WriteFile(token, []byte(`{"credenciales":"valiosas"}`), 0600); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+
+	fakeAzureCLI(t, "exit 1")
+	feedStdin(t, "acme\n"+testTenantID+"\n")
+	quiet(t)
+
+	if err := run(t, newAddCmd()); err == nil {
+		t.Fatal("add devolvió nil con az login fallando")
+	}
+
+	if _, err := os.Stat(tenantDir); err != nil {
+		t.Fatalf("se borró un directorio preexistente: %v", err)
+	}
+	data, err := os.ReadFile(token)
+	if err != nil {
+		t.Fatalf("se borraron las credenciales preexistentes: %v", err)
+	}
+	if string(data) != `{"credenciales":"valiosas"}` {
+		t.Errorf("las credenciales cambiaron: %s", data)
+	}
+}
+
+// Un nombre inválido debe rechazarse sin crear nada y sin llegar a pedir el
+// tenant ID.
+func TestAddRejectsInvalidNameWithoutTouchingDisk(t *testing.T) {
+	home := addSandbox(t)
+	fakeAzureCLI(t, "exit 0")
+	feedStdin(t, "Acme Corp\n"+testTenantID+"\n")
+	output := quiet(t)
+
+	if err := run(t, newAddCmd()); err == nil {
+		t.Fatal("add aceptó un nombre inválido")
+	}
+	if _, err := os.Stat(filepath.Join(home, "tenants")); !os.IsNotExist(err) {
+		t.Error("se creó el directorio de tenants pese al nombre inválido")
+	}
+	// El offset de stdin no sirve para comprobar esto: bufio.Reader lee por
+	// bloques, no por líneas. Lo que sí prueba que no se siguió adelante es
+	// que el segundo prompt nunca se imprimió.
+	if got := output(); strings.Contains(got, "Azure Tenant ID") {
+		t.Errorf("se pidió el tenant ID pese al nombre inválido:\n%s", got)
+	}
+}

--- a/cmd/az_required_test.go
+++ b/cmd/az_required_test.go
@@ -145,14 +145,19 @@ func feedStdin(t *testing.T, content string) *os.File {
 	return f
 }
 
-// fakeAzureCLI pone un az de mentira en el PATH con el cuerpo indicado. Deja
-// ejercitar el camino real —Available lo encuentra, Login lo ejecuta— sin
-// costuras y sin tocar Azure.
+// fakeAzureCLI pone un az de mentira delante del PATH con el cuerpo indicado.
+// Deja ejercitar el camino real —Available lo encuentra, Login lo ejecuta—
+// sin costuras y sin tocar Azure.
+//
+// Se antepone en vez de reemplazar el PATH: reemplazarlo dejaba al script sin
+// utilidades básicas, de modo que un cuerpo como `touch centinela` fallaba en
+// silencio con «command not found» y cualquier aserción sobre el centinela
+// resultaba vacía. Anteponerlo basta para que el az de mentira gane.
 func fakeAzureCLI(t *testing.T, body string) {
 	t.Helper()
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "az"), []byte("#!/bin/sh\n"+body+"\n"), 0755); err != nil {
 		t.Fatalf("escribiendo el az falso: %v", err)
 	}
-	t.Setenv("PATH", dir)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }

--- a/cmd/az_required_test.go
+++ b/cmd/az_required_test.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aolmosj/azsel/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// withoutAzureCLI points PATH at an empty directory, so exec.LookPath cannot
+// find az. Real rather than stubbed: azure.Available's seam is unexported and
+// this is what the user's machine actually looks like.
+func withoutAzureCLI(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv(config.EnvHome, home)
+	t.Setenv("PATH", t.TempDir())
+	return home
+}
+
+// quiet swallows the commands' direct writes to the process streams.
+func quiet(t *testing.T) {
+	t.Helper()
+	devnull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("abriendo %s: %v", os.DevNull, err)
+	}
+	outOrig, errOrig := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = devnull, devnull
+	t.Cleanup(func() {
+		os.Stdout, os.Stderr = outOrig, errOrig
+		devnull.Close()
+	})
+}
+
+func run(t *testing.T, c *cobra.Command, args ...string) error {
+	t.Helper()
+	c.SilenceErrors, c.SilenceUsage = true, true
+	c.SetOut(io.Discard)
+	c.SetErr(io.Discard)
+	c.SetArgs(args)
+	return c.Execute()
+}
+
+// El coste de que az falte debe ser el mensaje y nada más. Antes el usuario
+// escribía nombre y tenant ID, se creaba el directorio del tenant, y solo
+// entonces reventaba con el error crudo de Go.
+func TestAddFailsBeforeAskingAnything(t *testing.T) {
+	home := withoutAzureCLI(t)
+	quiet(t)
+
+	// Lo que el usuario habría tecleado si se le hubiera preguntado.
+	stdin := filepath.Join(t.TempDir(), "stdin")
+	if err := os.WriteFile(stdin, []byte("acme\n11111111-1111-1111-1111-111111111111\n"), 0644); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	f, err := os.Open(stdin)
+	if err != nil {
+		t.Fatalf("abriendo stdin falso: %v", err)
+	}
+	defer f.Close()
+	orig := os.Stdin
+	os.Stdin = f
+	t.Cleanup(func() { os.Stdin = orig })
+
+	err = run(t, newAddCmd())
+	if err == nil {
+		t.Fatal("add devolvió nil sin az instalado")
+	}
+	if !strings.Contains(err.Error(), "Azure CLI") {
+		t.Errorf("error = %q, quería que nombrara Azure CLI", err)
+	}
+	if !strings.Contains(err.Error(), "install") {
+		t.Errorf("error = %q, quería que dijera cómo instalarlo", err)
+	}
+
+	// Nada leído de stdin: no se llegó a preguntar.
+	if pos, _ := f.Seek(0, io.SeekCurrent); pos != 0 {
+		t.Errorf("se consumió stdin antes de comprobar az (offset %d)", pos)
+	}
+	// Y nada creado en disco.
+	if entries, err := os.ReadDir(filepath.Join(home, "tenants")); err == nil && len(entries) > 0 {
+		t.Errorf("se crearon %d directorios de tenant pese al fallo", len(entries))
+	}
+}
+
+// Solo add necesita az. El resto debe seguir funcionando en una máquina sin
+// Azure CLI — consultar tenants o cambiar de uno a otro no invoca nada.
+func TestCommandsThatDoNotNeedAzureCLI(t *testing.T) {
+	home := withoutAzureCLI(t)
+	quiet(t)
+
+	tenantDir := filepath.Join(home, "tenants", "acme")
+	if err := os.MkdirAll(tenantDir, 0755); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	cfg := &config.Config{Tenants: []config.Tenant{
+		{Name: "acme", TenantID: "11111111-1111-1111-1111-111111111111", ConfigDir: tenantDir},
+	}}
+	if err := config.Save(cfg); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		cmd  *cobra.Command
+		args []string
+	}{
+		{"list", newListCmd(), nil},
+		{"use", newUseCmd(), []string{"acme"}},
+		{"init --print", newInitCmd(), []string{"--print"}},
+		{"remove -f", newRemoveCmd(), []string{"acme", "-f"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if err := run(t, c.cmd, c.args...); err != nil {
+				t.Errorf("%s falló sin az instalado: %v", c.name, err)
+			}
+		})
+	}
+}

--- a/cmd/az_required_test.go
+++ b/cmd/az_required_test.go
@@ -22,19 +22,30 @@ func withoutAzureCLI(t *testing.T) string {
 	return home
 }
 
-// quiet swallows the commands' direct writes to the process streams.
-func quiet(t *testing.T) {
+// quiet swallows the commands' direct writes to the process streams and
+// returns a function reading back everything they wrote. The commands write
+// straight to os.Stdout/os.Stderr rather than through cobra, so redirecting
+// the process streams is the only way to see their output.
+func quiet(t *testing.T) func() string {
 	t.Helper()
-	devnull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	path := filepath.Join(t.TempDir(), "output")
+	f, err := os.Create(path)
 	if err != nil {
-		t.Fatalf("abriendo %s: %v", os.DevNull, err)
+		t.Fatalf("creando el fichero de salida: %v", err)
 	}
 	outOrig, errOrig := os.Stdout, os.Stderr
-	os.Stdout, os.Stderr = devnull, devnull
+	os.Stdout, os.Stderr = f, f
 	t.Cleanup(func() {
 		os.Stdout, os.Stderr = outOrig, errOrig
-		devnull.Close()
+		f.Close()
 	})
+	return func() string {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("leyendo la salida: %v", err)
+		}
+		return string(data)
+	}
 }
 
 func run(t *testing.T, c *cobra.Command, args ...string) error {
@@ -54,20 +65,9 @@ func TestAddFailsBeforeAskingAnything(t *testing.T) {
 	quiet(t)
 
 	// Lo que el usuario habría tecleado si se le hubiera preguntado.
-	stdin := filepath.Join(t.TempDir(), "stdin")
-	if err := os.WriteFile(stdin, []byte("acme\n11111111-1111-1111-1111-111111111111\n"), 0644); err != nil {
-		t.Fatalf("preparando: %v", err)
-	}
-	f, err := os.Open(stdin)
-	if err != nil {
-		t.Fatalf("abriendo stdin falso: %v", err)
-	}
-	defer f.Close()
-	orig := os.Stdin
-	os.Stdin = f
-	t.Cleanup(func() { os.Stdin = orig })
+	f := feedStdin(t, "acme\n11111111-1111-1111-1111-111111111111\n")
 
-	err = run(t, newAddCmd())
+	err := run(t, newAddCmd())
 	if err == nil {
 		t.Fatal("add devolvió nil sin az instalado")
 	}
@@ -122,4 +122,37 @@ func TestCommandsThatDoNotNeedAzureCLI(t *testing.T) {
 			}
 		})
 	}
+}
+
+// feedStdin conecta os.Stdin a un fichero con lo que el usuario teclearía, y
+// devuelve el descriptor para poder comprobar cuánto se ha llegado a leer.
+func feedStdin(t *testing.T, content string) *os.File {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "stdin")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("preparando stdin: %v", err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("abriendo stdin falso: %v", err)
+	}
+	orig := os.Stdin
+	os.Stdin = f
+	t.Cleanup(func() {
+		os.Stdin = orig
+		f.Close()
+	})
+	return f
+}
+
+// fakeAzureCLI pone un az de mentira en el PATH con el cuerpo indicado. Deja
+// ejercitar el camino real —Available lo encuentra, Login lo ejecuta— sin
+// costuras y sin tocar Azure.
+func fakeAzureCLI(t *testing.T, body string) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "az"), []byte("#!/bin/sh\n"+body+"\n"), 0755); err != nil {
+		t.Fatalf("escribiendo el az falso: %v", err)
+	}
+	t.Setenv("PATH", dir)
 }

--- a/cmd/tenant_id_test.go
+++ b/cmd/tenant_id_test.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeTenantIDAccepts(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+		why  string
+	}{
+		{"11111111-1111-1111-1111-111111111111", "11111111-1111-1111-1111-111111111111", "GUID en minúsculas"},
+		{"AABBCCDD-1122-3344-5566-778899AABBCC", "aabbccdd-1122-3344-5566-778899aabbcc", "GUID en mayúsculas, normalizado"},
+		{"  11111111-1111-1111-1111-111111111111  ", "11111111-1111-1111-1111-111111111111", "espacios alrededor"},
+		{"11111111-1111-1111-1111-111111111111\n", "11111111-1111-1111-1111-111111111111", "salto de línea del prompt"},
+
+		// az login --tenant también acepta un dominio verificado del tenant.
+		{"contoso.onmicrosoft.com", "contoso.onmicrosoft.com", "dominio onmicrosoft"},
+		{"CONTOSO.ONMICROSOFT.COM", "contoso.onmicrosoft.com", "dominio en mayúsculas"},
+		{"contoso.com", "contoso.com", "dominio propio"},
+		{"my-tenant.example.co.uk", "my-tenant.example.co.uk", "guiones y varios niveles"},
+	}
+	for _, c := range cases {
+		got, err := normalizeTenantID(c.in)
+		if err != nil {
+			t.Errorf("normalizeTenantID(%q) = error %v, quería aceptarlo (%s)", c.in, err, c.why)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("normalizeTenantID(%q) = %q, quería %q (%s)", c.in, got, c.want, c.why)
+		}
+	}
+}
+
+func TestNormalizeTenantIDRejects(t *testing.T) {
+	cases := []struct {
+		in  string
+		why string
+	}{
+		{"", "vacío"},
+		{"   ", "solo espacios"},
+		{"contoso", "nombre suelto, sin punto ni forma de GUID"},
+		{"11111111-1111-1111-1111-11111111111", "GUID con un dígito de menos"},
+		{"11111111-1111-1111-1111-1111111111111", "GUID con un dígito de más"},
+		{"11111111-1111-1111-111111111111111", "faltan guiones"},
+		{"gggggggg-1111-1111-1111-111111111111", "caracteres fuera de hexadecimal"},
+		{"11111111 1111 1111 1111 111111111111", "espacios en vez de guiones"},
+		{"-contoso.com", "etiqueta que empieza por guión"},
+		{"contoso-.com", "etiqueta que acaba en guión"},
+		{"contoso..com", "etiqueta vacía"},
+		{"contoso.com.", "punto final"},
+		{".contoso.com", "punto inicial"},
+		{"https://contoso.onmicrosoft.com", "una URL, no un dominio"},
+		{"contoso onmicrosoft com", "espacios"},
+	}
+	for _, c := range cases {
+		if got, err := normalizeTenantID(c.in); err == nil {
+			t.Errorf("normalizeTenantID(%q) = %q, quería rechazarlo (%s)", c.in, got, c.why)
+		}
+	}
+}
+
+// El mensaje tiene que decir qué se esperaba, no solo que está mal: el usuario
+// acaba de pegar algo y necesita saber qué formato quiere azsel.
+func TestNormalizeTenantIDErrorNamesBothFormats(t *testing.T) {
+	_, err := normalizeTenantID("no-soy-un-tenant")
+	if err == nil {
+		t.Fatal("se aceptó un tenant ID inválido")
+	}
+	got := err.Error()
+	for _, want := range []string{"no-soy-un-tenant", "GUID", "domain"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("error = %q, quería que mencionara %q", got, want)
+		}
+	}
+}

--- a/internal/azure/azure.go
+++ b/internal/azure/azure.go
@@ -44,6 +44,12 @@ func Available() error {
 // command builds an az invocation scoped to one tenant's directories. The
 // environment is inherited so az keeps the user's proxy, locale and so on;
 // only the two directories azsel controls are overridden.
+//
+// Those two may already be exported — by azsel itself in an active session,
+// or by an Azure CLI install that sets AZURE_EXTENSION_DIR system-wide. That
+// is fine: os/exec deduplicates Env keeping the last occurrence, so what is
+// appended here wins. TestCommandEnvOverridesInheritedValues pins it, because
+// the guarantee is not obvious from reading this.
 func command(configDir, extensionsDir string, args ...string) *exec.Cmd {
 	cmd := exec.Command(binary, args...)
 	cmd.Env = append(os.Environ(),

--- a/internal/azure/azure.go
+++ b/internal/azure/azure.go
@@ -1,11 +1,27 @@
 package azure
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 )
+
+// binary is the Azure CLI executable azsel drives.
+const binary = "az"
+
+// run executes a prepared command.
+//
+// It is a package variable so tests can observe the command azsel builds —
+// arguments, environment, stream wiring — without an Azure CLI installed, a
+// browser opening or a network. #9 and #10 need this seam more than this
+// package does: one has to simulate a failed login, the other a missing az.
+var run = func(cmd *exec.Cmd) error { return cmd.Run() }
+
+// lookPath resolves an executable on PATH, injectable for the same reason.
+var lookPath = exec.LookPath
 
 type AccountInfo struct {
 	TenantID string `json:"tenantId"`
@@ -15,28 +31,60 @@ type AccountInfo struct {
 	} `json:"user"`
 }
 
+// Available reports whether the Azure CLI can be found. Commands that shell
+// out to az should check this before doing anything the user would have to
+// undo — see #10.
+func Available() error {
+	if _, err := lookPath(binary); err != nil {
+		return fmt.Errorf("Azure CLI (%s) not found in PATH: %w", binary, err)
+	}
+	return nil
+}
+
+// command builds an az invocation scoped to one tenant's directories. The
+// environment is inherited so az keeps the user's proxy, locale and so on;
+// only the two directories azsel controls are overridden.
+func command(configDir, extensionsDir string, args ...string) *exec.Cmd {
+	cmd := exec.Command(binary, args...)
+	cmd.Env = append(os.Environ(),
+		"AZURE_CONFIG_DIR="+configDir,
+		"AZURE_EXTENSION_DIR="+extensionsDir,
+	)
+	return cmd
+}
+
 func Login(tenantID, configDir, extensionsDir string, useDeviceCode bool) error {
 	args := []string{"login", "--tenant", tenantID}
 	if useDeviceCode {
 		args = append(args, "--use-device-code")
 	}
-	cmd := exec.Command("az", args...)
-	cmd.Env = append(os.Environ(), "AZURE_CONFIG_DIR="+configDir, "AZURE_EXTENSION_DIR="+extensionsDir)
+	cmd := command(configDir, extensionsDir, args...)
+	// Deliberate, and easy to undo by accident: the login is interactive, so
+	// stdin must reach az; and az's stdout is sent to stderr because azsel
+	// keeps stdout clean for the shell to consume.
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	return run(cmd)
 }
 
 func AccountShow(configDir, extensionsDir string) (*AccountInfo, error) {
-	cmd := exec.Command("az", "account", "show", "--output", "json")
-	cmd.Env = append(os.Environ(), "AZURE_CONFIG_DIR="+configDir, "AZURE_EXTENSION_DIR="+extensionsDir)
-	out, err := cmd.Output()
-	if err != nil {
+	cmd := command(configDir, extensionsDir, "account", "show", "--output", "json")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := run(cmd); err != nil {
+		// az explains itself on stderr; without this the caller only sees
+		// "exit status 1".
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return nil, fmt.Errorf("az account show: %w: %s", err, msg)
+		}
 		return nil, fmt.Errorf("az account show: %w", err)
 	}
+
 	var info AccountInfo
-	if err := json.Unmarshal(out, &info); err != nil {
+	if err := json.Unmarshal(stdout.Bytes(), &info); err != nil {
 		return nil, fmt.Errorf("parsing account info: %w", err)
 	}
 	return &info, nil

--- a/internal/azure/azure.go
+++ b/internal/azure/azure.go
@@ -31,12 +31,19 @@ type AccountInfo struct {
 	} `json:"user"`
 }
 
+// installURL is where to get the Azure CLI when it turns out to be missing.
+const installURL = "https://learn.microsoft.com/cli/azure/install-azure-cli"
+
 // Available reports whether the Azure CLI can be found. Commands that shell
-// out to az should check this before doing anything the user would have to
-// undo — see #10.
+// out to az should call this before doing anything the user would have to
+// undo — asking for input, creating directories — so a missing az costs
+// nothing but the message.
+//
+// LookPath's own error ("executable file not found in $PATH") only restates
+// this one, so it is not wrapped; what the user needs is where to get az.
 func Available() error {
 	if _, err := lookPath(binary); err != nil {
-		return fmt.Errorf("Azure CLI (%s) not found in PATH: %w", binary, err)
+		return fmt.Errorf("Azure CLI (%s) not found in PATH.\nInstall it: %s", binary, installURL)
 	}
 	return nil
 }

--- a/internal/azure/azure_test.go
+++ b/internal/azure/azure_test.go
@@ -1,0 +1,228 @@
+package azure
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// capture holds the command handed to run, so a test can inspect what azsel
+// built without anything being executed.
+type capture struct{ cmd *exec.Cmd }
+
+// stubRun replaces the executor for one test. fn may be nil to succeed.
+func stubRun(t *testing.T, fn func(*exec.Cmd) error) *capture {
+	t.Helper()
+	c := &capture{}
+	orig := run
+	run = func(cmd *exec.Cmd) error {
+		c.cmd = cmd
+		if fn == nil {
+			return nil
+		}
+		return fn(cmd)
+	}
+	t.Cleanup(func() { run = orig })
+	return c
+}
+
+func stubLookPath(t *testing.T, fn func(string) (string, error)) {
+	t.Helper()
+	orig := lookPath
+	lookPath = fn
+	t.Cleanup(func() { lookPath = orig })
+}
+
+func envValue(cmd *exec.Cmd, key string) (string, bool) {
+	for _, kv := range cmd.Env {
+		if name, value, ok := strings.Cut(kv, "="); ok && name == key {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+func TestLoginArguments(t *testing.T) {
+	cases := []struct {
+		name       string
+		deviceCode bool
+		want       []string
+	}{
+		{"navegador", false, []string{"az", "login", "--tenant", "TID"}},
+		{"device code", true, []string{"az", "login", "--tenant", "TID", "--use-device-code"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := stubRun(t, nil)
+			if err := Login("TID", "/cfg", "/ext", c.deviceCode); err != nil {
+				t.Fatalf("Login: %v", err)
+			}
+			if !slices.Equal(got.cmd.Args, c.want) {
+				t.Errorf("args = %v, quería %v", got.cmd.Args, c.want)
+			}
+		})
+	}
+}
+
+// El aislamiento entre tenants depende enteramente de estas dos variables.
+func TestLoginScopesTheEnvironment(t *testing.T) {
+	got := stubRun(t, nil)
+	if err := Login("TID", "/cfg/acme", "/ext", false); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+
+	for _, c := range []struct{ key, want string }{
+		{"AZURE_CONFIG_DIR", "/cfg/acme"},
+		{"AZURE_EXTENSION_DIR", "/ext"},
+	} {
+		if v, ok := envValue(got.cmd, c.key); !ok || v != c.want {
+			t.Errorf("%s = %q (presente=%v), quería %q", c.key, v, ok, c.want)
+		}
+	}
+
+	// El resto del entorno se hereda: az necesita proxy, locale, HOME...
+	if _, ok := envValue(got.cmd, "PATH"); !ok {
+		t.Error("no se heredó el entorno del proceso")
+	}
+}
+
+// Dos comportamientos deliberados y fáciles de romper sin querer: el login es
+// interactivo, así que stdin debe llegar a az; y la salida de az va a stderr
+// porque azsel mantiene stdout limpio para el shell.
+func TestLoginWiresStreams(t *testing.T) {
+	got := stubRun(t, nil)
+	if err := Login("TID", "/cfg", "/ext", false); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if got.cmd.Stdin != os.Stdin {
+		t.Error("stdin no está conectado: el login interactivo no funcionaría")
+	}
+	if got.cmd.Stdout != os.Stderr {
+		t.Error("stdout de az no va a stderr: ensuciaría la salida estándar")
+	}
+	if got.cmd.Stderr != os.Stderr {
+		t.Error("stderr de az no va a stderr")
+	}
+}
+
+func TestLoginPropagatesFailure(t *testing.T) {
+	want := errors.New("el usuario canceló")
+	stubRun(t, func(*exec.Cmd) error { return want })
+
+	err := Login("TID", "/cfg", "/ext", false)
+	if !errors.Is(err, want) {
+		t.Errorf("error = %v, quería %v", err, want)
+	}
+}
+
+func TestAccountShowParsesJSON(t *testing.T) {
+	const payload = `{
+	  "tenantId": "11111111-1111-1111-1111-111111111111",
+	  "name": "Contoso Production",
+	  "user": {"name": "juan@contoso.com"}
+	}`
+	got := stubRun(t, func(cmd *exec.Cmd) error {
+		_, err := cmd.Stdout.Write([]byte(payload))
+		return err
+	})
+
+	info, err := AccountShow("/cfg", "/ext")
+	if err != nil {
+		t.Fatalf("AccountShow: %v", err)
+	}
+	if info.TenantID != "11111111-1111-1111-1111-111111111111" {
+		t.Errorf("TenantID = %q", info.TenantID)
+	}
+	if info.Name != "Contoso Production" {
+		t.Errorf("Name = %q", info.Name)
+	}
+	if info.User.Name != "juan@contoso.com" {
+		t.Errorf("User.Name = %q", info.User.Name)
+	}
+
+	want := []string{"az", "account", "show", "--output", "json"}
+	if !slices.Equal(got.cmd.Args, want) {
+		t.Errorf("args = %v, quería %v", got.cmd.Args, want)
+	}
+}
+
+func TestAccountShowRejectsInvalidJSON(t *testing.T) {
+	stubRun(t, func(cmd *exec.Cmd) error {
+		_, err := cmd.Stdout.Write([]byte("no soy json"))
+		return err
+	})
+
+	_, err := AccountShow("/cfg", "/ext")
+	if err == nil {
+		t.Fatal("AccountShow devolvió nil sobre JSON inválido")
+	}
+	if !strings.Contains(err.Error(), "parsing account info") {
+		t.Errorf("error = %q, quería que mencionara «parsing account info»", err)
+	}
+}
+
+// az se explica por stderr; sin esto el usuario solo ve «exit status 1».
+func TestAccountShowIncludesStderrInError(t *testing.T) {
+	stubRun(t, func(cmd *exec.Cmd) error {
+		fmt.Fprint(cmd.Stderr, "ERROR: Please run 'az login' to setup account.")
+		return errors.New("exit status 1")
+	})
+
+	_, err := AccountShow("/cfg", "/ext")
+	if err == nil {
+		t.Fatal("AccountShow devolvió nil ante un fallo de az")
+	}
+	if !strings.Contains(err.Error(), "az login") {
+		t.Errorf("error = %q, quería que incluyera lo que dijo az por stderr", err)
+	}
+}
+
+func TestAccountShowWithoutStderr(t *testing.T) {
+	want := errors.New("exit status 2")
+	stubRun(t, func(*exec.Cmd) error { return want })
+
+	_, err := AccountShow("/cfg", "/ext")
+	if !errors.Is(err, want) {
+		t.Errorf("error = %v, quería envolver a %v", err, want)
+	}
+}
+
+func TestAvailable(t *testing.T) {
+	t.Run("az presente", func(t *testing.T) {
+		stubLookPath(t, func(string) (string, error) { return "/usr/local/bin/az", nil })
+		if err := Available(); err != nil {
+			t.Errorf("Available: %v", err)
+		}
+	})
+
+	t.Run("az ausente", func(t *testing.T) {
+		stubLookPath(t, func(name string) (string, error) {
+			return "", fmt.Errorf("exec: %q: executable file not found in $PATH", name)
+		})
+		err := Available()
+		if err == nil {
+			t.Fatal("Available devolvió nil sin az en el PATH")
+		}
+		if !strings.Contains(err.Error(), "Azure CLI") {
+			t.Errorf("error = %q, quería que nombrara Azure CLI", err)
+		}
+	})
+
+	t.Run("se consulta el binario correcto", func(t *testing.T) {
+		var asked string
+		stubLookPath(t, func(name string) (string, error) {
+			asked = name
+			return "/usr/local/bin/az", nil
+		})
+		if err := Available(); err != nil {
+			t.Fatalf("Available: %v", err)
+		}
+		if asked != "az" {
+			t.Errorf("se buscó %q, quería «az»", asked)
+		}
+	})
+}

--- a/internal/azure/azure_test.go
+++ b/internal/azure/azure_test.go
@@ -37,13 +37,20 @@ func stubLookPath(t *testing.T, fn func(string) (string, error)) {
 	t.Cleanup(func() { lookPath = orig })
 }
 
+// envValue reports the value the subprocess will actually see. os/exec
+// deduplicates Env keeping the *last* occurrence, so a key inherited from the
+// parent and then overridden appears twice and the later one wins. Reading
+// the first match instead is how this helper originally got it wrong: it
+// passed on macOS, where nothing pre-sets these, and failed on a CI runner
+// that ships with AZURE_EXTENSION_DIR already exported.
 func envValue(cmd *exec.Cmd, key string) (string, bool) {
+	value, found := "", false
 	for _, kv := range cmd.Env {
-		if name, value, ok := strings.Cut(kv, "="); ok && name == key {
-			return value, true
+		if name, v, ok := strings.Cut(kv, "="); ok && name == key {
+			value, found = v, true
 		}
 	}
-	return "", false
+	return value, found
 }
 
 func TestLoginArguments(t *testing.T) {
@@ -225,4 +232,27 @@ func TestAvailable(t *testing.T) {
 			t.Errorf("se buscó %q, quería «az»", asked)
 		}
 	})
+}
+
+// azsel's whole isolation model rests on overriding these two variables, and
+// they may well already be exported — by azsel itself in an active session,
+// or by an Azure CLI install like the one on GitHub's Linux runners. Whatever
+// azsel appends has to win.
+func TestCommandEnvOverridesInheritedValues(t *testing.T) {
+	t.Setenv("AZURE_CONFIG_DIR", "/heredado/config")
+	t.Setenv("AZURE_EXTENSION_DIR", "/heredado/extensions")
+
+	got := stubRun(t, nil)
+	if err := Login("TID", "/cfg/acme", "/ext/compartido", false); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+
+	for _, c := range []struct{ key, want string }{
+		{"AZURE_CONFIG_DIR", "/cfg/acme"},
+		{"AZURE_EXTENSION_DIR", "/ext/compartido"},
+	} {
+		if v, _ := envValue(got.cmd, c.key); v != c.want {
+			t.Errorf("%s efectivo = %q, quería %q", c.key, v, c.want)
+		}
+	}
 }


### PR DESCRIPTION
Third batch of Phase 1 (#13): the `add` flow and what's needed to be able to test it.

## Scope

- [x] #15 — `internal/azure`: inject the command executor
- [x] #10 — `az` isn't checked for on `PATH` before invoking it
- [x] #9 — A failed login leaves the tenant directory orphaned
- [x] #8 — The Tenant ID format isn't validated

The order matters: #15 goes first because #9 needs a `Login` double that fails and #10 needs to simulate `az` being absent.

## #15 — Executor injection

`internal/azure` called `exec.Command` directly, so **nothing in it could be tested**: any test of `Login` would have run `az` for real, opened a browser and needed credentials. It was the only package with zero coverage.

Two package variables give the seam: `run`, which executes an already-prepared command, and `lookPath`. Tests substitute them and **inspect what azsel builds** instead of what happened.

The issue raised an `Executor` interface as a more formal alternative. For two functions it adds nothing the variables don't already give, so it stayed lightweight.

### Side effect that improves errors

`AccountShow` moves from `cmd.Output()` to writing into buffers through the same seam. That unifies the two invocation styles and, along the way, **puts `az`'s stderr into the error**. Before, a failure arrived as a terse `exit status 1` while `az` had explained the reason:

```
az account show: exit status 1: ERROR: Please run 'az login' to setup account.
```

### `Available()`

New, and **nobody calls it yet**: #10 decides where the check goes and what it says, and needed this seam to be able to test it.

### Coverage

From **0% to 96.3%**. The suite passes with `az` entirely absent from `PATH`, verified:

```
$ PATH=<no az> go test ./internal/azure/
ok      github.com/aolmosj/azsel/internal/azure
```

Two deliberate but undefended behaviors get a test: `Login` connects `stdin` so interactive login works, and sends `az`'s stdout to **stderr** because azsel keeps stdout clean for the shell. Either one could be broken by accident in a refactor and no one would notice.

### Note on `AccountShow` and #5

The issue asked to coordinate with #5 before writing tests for it, because that issue may end up **removing** `AccountShow`. They were written anyway: they're cheap, they document the current contract, and if #5 decides to delete the function they go with it. The alternative — leaving the package's only JSON-parsing function uncovered — came out worse.

## #10 — Check `az` before anything

Without the Azure CLI installed, `azsel add` asked for the tenant name, asked for the tenant ID, created `~/.azsel/tenants/<name>/` and **only then** failed with Go's raw wrapper:

```
Error: az login failed: exec: "az": executable file not found in $PATH
```

Everything typed was lost and the directory stayed behind.

`azure.Available()` — added in #15 — is now called as the **first statement** of `add`'s `RunE`, before the prompts and before any directory exists:

```
Error: Azure CLI (az) not found in PATH.
Install it: https://learn.microsoft.com/cli/azure/install-azure-cli
```

**No global check on the root**: `list`, `use`, `remove`, `init` and the TUI don't touch `az` and must keep working on a machine without it. A test runs each one with `PATH` pointing at an empty directory.

The `add` test asserts the two things that make the failure cheap: stdin is still at offset zero — nothing was ever asked — and no tenant directory exists. Moving the check back to just before the login, it fails on both: 42 bytes consumed and a directory created. **That directory is the same orphan #9 is about.**

## #9 — Rollback of a failed login

`EnsureTenantDir` returned the `created bool` from #7 and `add` discarded it with `_` pending this issue. It now deletes the directory **only if that run created it**.

The distinction is the whole point: a pre-existing directory may hold valid credentials from an earlier attempt, and deleting them would turn a failed login into a lost session. **A careless fix here would be worse than the bug.**

The tests drive the real path with a fake `az` on `PATH` instead of a `Login` double. Both failure modes verified by breaking the code:

| Broken code | Test that catches it |
|---|---|
| No rollback (the original bug) | `the directory was left orphaned` |
| Unconditional rollback | `a pre-existing directory was deleted` |

Out of scope: the `azsel prune` command the issue raised as "consider". It's new user surface, not a fix. Noted on the issue.

## #8 — Tenant ID validation

The nuance the issue captured was the central point: `az login --tenant` accepts **a GUID and a verified domain**, so validating only a GUID would break a legitimate case.

```
Azure Tenant ID (GUID or domain): contoso
Error: invalid tenant ID "contoso" — expected a GUID such as
11111111-1111-1111-1111-111111111111, or a domain such as
contoso.onmicrosoft.com
```

**Lowercasing matters more than it looks.** Both forms are case-insensitive; without it the same tenant with different casing would end up as two entries in `config.json`, and the `ACTIVE` column of `azsel list` — which compares strings — could contradict itself.

A table with 8 accepted and 15 rejected forms, plus two integration tests: that `az` isn't invoked with an invalid ID, and that the normalization reaches `config.json`.

---

Closes #15
Closes #10
Closes #9
Closes #8
