### PR TITLE
Phase 1 · Batch 5 — Pending items

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,20 @@ jobs:
 
       - run: go test -race ./...
 
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12.2
+
   format:
     name: Format
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,58 @@
+version: "2"
+
+linters:
+  # Conjunto explícito, no el de por defecto. Cada linter está aquí porque
+  # cubre algo que `go vet` no mira. staticcheck se deja para más adelante y
+  # en un PR aparte: es el que más ruido genera de entrada y conviene que su
+  # triaje no se mezcle con el del resto.
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - unused
+    - gosec
+
+  settings:
+    errcheck:
+      # Toda la salida visible de azsel va a stderr, y la tabla de `list` pasa
+      # por un tabwriter cuyo Flush() sí se comprueba — que es donde aflora
+      # cualquier error de escritura. Comprobar cada Fprintf a stderr solo
+      # añadiría ruido sin cubrir nada.
+      exclude-functions:
+        - fmt.Fprint
+        - fmt.Fprintf
+        - fmt.Fprintln
+
+  exclusions:
+    rules:
+      # Los tests crean ficheros y directorios con permisos concretos a
+      # propósito: en varios casos el permiso *es* lo que se está probando.
+      - path: _test\.go
+        linters:
+          - gosec
+
+      # Ejecutar az con argumentos variables es la razón de ser del paquete.
+      # El binario es una constante y los argumentos van como elementos de
+      # argv, no a través de un shell, así que no hay inyección posible.
+      - path: internal/azure/azure\.go
+        linters:
+          - gosec
+        text: "G204"
+
+      # La ruta sale de BaseDir(), que es del propio azsel (o de AZSEL_HOME,
+      # que define el usuario para sí mismo). No hay entrada externa.
+      - path: internal/config/config\.go
+        linters:
+          - gosec
+        text: "G304"
+
+      # G302: 0644 es la convención para un fichero rc de shell, y el flag
+      # O_CREATE solo aplica permisos cuando el fichero no existe — lo normal
+      # es que ya esté ahí.
+      # G304: la ruta la produce detectShellRC() a partir de $SHELL y $HOME
+      # del propio usuario. No hay entrada externa.
+      - path: cmd/init\.go
+        linters:
+          - gosec
+        text: "G30[24]"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Azure CLI stores its configuration (auth tokens, default subscription, etc.) in 
 
 Azure CLI extensions are shared across all profiles via a common `~/.azsel/extensions/` directory (using `AZURE_EXTENSION_DIR`), so you only need to install each extension once.
 
+Those directories are created `0700`, and `config.json` is written `0600`. Azure CLI protects its token cache itself, but leaves `azureProfile.json`, `az.sess` and its HTTP cache world-readable, so the directory bit is the only lever `azsel` has over who else on the machine can read them. Directories that already exist keep the permissions they have.
+
 The location of `~/.azsel/` itself can be overridden with the `AZSEL_HOME` environment variable — useful for dotfile setups, containers, or keeping separate sets of profiles:
 
 ```bash
@@ -278,6 +280,7 @@ go test -race -cover ./...   # what CI runs
 go build -o azsel .
 go vet ./...
 gofmt -l .                   # must print nothing
+golangci-lint run ./...      # config in .golangci.yml
 ```
 
 ### Manual test flow

--- a/cmd/add_rollback_test.go
+++ b/cmd/add_rollback_test.go
@@ -216,7 +216,7 @@ func TestAddRemovesDirectoryWhenConfigCannotBeSaved(t *testing.T) {
 		t.Fatalf("preparando: %v", err)
 	}
 	// Devolver el permiso de escritura para que t.TempDir pueda limpiar.
-	t.Cleanup(func() { os.Chmod(home, 0755) })
+	t.Cleanup(func() { _ = os.Chmod(home, 0755) })
 
 	fakeAzureCLI(t, "exit 0")
 	feedStdin(t, "acme\n"+testTenantID+"\n")

--- a/cmd/az_required_test.go
+++ b/cmd/az_required_test.go
@@ -37,7 +37,7 @@ func quiet(t *testing.T) func() string {
 	os.Stdout, os.Stderr = f, f
 	t.Cleanup(func() {
 		os.Stdout, os.Stderr = outOrig, errOrig
-		f.Close()
+		_ = f.Close()
 	})
 	return func() string {
 		data, err := os.ReadFile(path)
@@ -140,7 +140,7 @@ func feedStdin(t *testing.T, content string) *os.File {
 	os.Stdin = f
 	t.Cleanup(func() {
 		os.Stdin = orig
-		f.Close()
+		_ = f.Close()
 	})
 	return f
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -142,10 +142,15 @@ func newInitCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("opening %s: %w", rcFile, err)
 			}
-			defer f.Close()
-
 			if _, err := fmt.Fprintf(f, "\n# azsel — Azure tenant selector\n%s\n", initLine); err != nil {
+				_ = f.Close()
 				return fmt.Errorf("writing to %s: %w", rcFile, err)
+			}
+			// Checked rather than deferred: a failing Close on a file just
+			// written can mean the append never reached disk, and the user
+			// would be told their shell was configured when it was not.
+			if err := f.Close(); err != nil {
+				return fmt.Errorf("closing %s: %w", rcFile, err)
 			}
 
 			fmt.Fprintf(os.Stderr, "Added azsel init to %s\n", rcFile)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,16 @@ const EnvSwitchFile = "AZSEL_SWITCH_FILE"
 // old is certainly abandoned.
 const staleSwitchAge = 24 * time.Hour
 
+// dirPerm is 0700 rather than 0755 because these directories hold Azure
+// credentials. az protects its token cache itself (0600) but writes
+// azureProfile.json, az.sess and msal_http_cache.bin at 0644, so the
+// directory bit is the only lever azsel has over who can read them.
+//
+// Applied on creation only: an existing ~/.azsel keeps whatever it has, since
+// silently changing permissions on a directory the user already owns is more
+// surprise than it is worth.
+const dirPerm = 0700
+
 type Tenant struct {
 	Name      string `json:"name"`
 	TenantID  string `json:"tenantId"`
@@ -88,7 +98,7 @@ func ensureDir(path string) (created bool, err error) {
 	case !os.IsNotExist(err):
 		return false, err
 	}
-	if err := os.MkdirAll(path, 0755); err != nil {
+	if err := os.MkdirAll(path, dirPerm); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -194,7 +204,9 @@ func pruneStaleSwitchFiles() {
 			continue
 		}
 		if time.Since(info.ModTime()) > staleSwitchAge {
-			os.Remove(filepath.Join(base, e.Name()))
+			// Best effort by design: a sweep that cannot delete must never
+			// make a tenant switch fail.
+			_ = os.Remove(filepath.Join(base, e.Name()))
 		}
 	}
 }
@@ -230,8 +242,15 @@ func Save(cfg *Config) error {
 	if err != nil {
 		return fmt.Errorf("marshaling config: %w", err)
 	}
-	if err := os.WriteFile(path, data, 0644); err != nil {
+	// 0600 for the same reason as the switch file: config.json decides which
+	// directory ends up in AZURE_CONFIG_DIR, so anyone who can write it
+	// chooses what the shell sources. Chmod because WriteFile only applies
+	// perm when it creates the file, and older versions wrote 0644.
+	if err := os.WriteFile(path, data, 0600); err != nil {
 		return fmt.Errorf("writing config: %w", err)
+	}
+	if err := os.Chmod(path, 0600); err != nil {
+		return fmt.Errorf("securing config: %w", err)
 	}
 	return nil
 }

--- a/internal/tui/delegate.go
+++ b/internal/tui/delegate.go
@@ -54,11 +54,18 @@ func (d tenantDelegate) Render(w io.Writer, m list.Model, index int, listItem li
 		descStyle.Render(desc))
 }
 
+// ShortHelp declares only the keys the list does not know about.
+//
+// list.Model.ShortHelp splices the delegate's bindings between the cursor
+// keys and its own KeyMap, which already contributes Filter and Quit. Listing
+// those here too printed them twice: "… / filter • q quit • / filter • q
+// quit • ? more".
+//
+// enter is the one binding that belongs to this delegate — tenantDelegate
+// handles it in Update; the list's KeyMap has no idea it exists.
 func (d tenantDelegate) ShortHelp() []key.Binding {
 	return []key.Binding{
 		key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "activate")),
-		key.NewBinding(key.WithKeys("/"), key.WithHelp("/", "filter")),
-		key.NewBinding(key.WithKeys("q"), key.WithHelp("q", "quit")),
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -243,3 +243,90 @@ func TestDelegateRenderShowsSameDataSelectedOrNot(t *testing.T) {
 		}
 	}
 }
+
+// helpKeys devuelve las teclas visibles en la barra de ayuda. Las bindings
+// deshabilitadas están en el slice pero el componente de ayuda no las pinta.
+func helpKeys(m Model) []string {
+	var keys []string
+	for _, b := range m.list.ShortHelp() {
+		if b.Enabled() {
+			keys = append(keys, b.Help().Key)
+		}
+	}
+	return keys
+}
+
+// list.Model.ShortHelp intercala las bindings del delegate entre las teclas
+// de cursor y su propio KeyMap, que ya aporta Filter y Quit. Declararlas
+// también en el delegate las imprimía dos veces.
+func TestHelpHasNoDuplicateKeys(t *testing.T) {
+	m := NewModel(tenants(), "")
+
+	seen := map[string]int{}
+	for _, k := range helpKeys(m) {
+		seen[k]++
+	}
+	for k, n := range seen {
+		if n > 1 {
+			t.Errorf("la tecla %q aparece %d veces en la ayuda: %v", k, n, helpKeys(m))
+		}
+	}
+}
+
+// El delegate solo debe aportar lo que el list no sabe. enter lo maneja él;
+// «/» y «q» las pone el list por su cuenta.
+func TestHelpContentsAreComplete(t *testing.T) {
+	m := NewModel(tenants(), "")
+	keys := helpKeys(m)
+
+	has := func(want string) bool {
+		for _, k := range keys {
+			if k == want {
+				return true
+			}
+		}
+		return false
+	}
+	for _, want := range []string{"enter", "/", "q"} {
+		if !has(want) {
+			t.Errorf("falta %q en la ayuda: %v", want, keys)
+		}
+	}
+
+	if got := newDelegate().ShortHelp(); len(got) != 1 {
+		t.Errorf("el delegate declara %d bindings, quería 1 (solo enter)", len(got))
+	}
+}
+
+// Con el filtro abierto la barra cambia de forma: el list omite el ShortHelp
+// del delegate. Tampoco ahí debe haber repeticiones.
+func TestHelpHasNoDuplicateKeysWhileFiltering(t *testing.T) {
+	m := NewModel(tenants(), "")
+	m, _ = send(t, m, keyMsg("/"))
+	if m.list.FilterState() != list.Filtering {
+		t.Fatalf("no se entró en modo filtro: %v", m.list.FilterState())
+	}
+
+	seen := map[string]int{}
+	for _, k := range helpKeys(m) {
+		seen[k]++
+	}
+	for k, n := range seen {
+		if n > 1 {
+			t.Errorf("filtrando, la tecla %q aparece %d veces: %v", k, n, helpKeys(m))
+		}
+	}
+}
+
+// Y la comprobación de extremo a extremo, sobre lo que el usuario ve.
+func TestRenderedHelpHasNoRepeatedEntries(t *testing.T) {
+	m := NewModel(tenants(), "")
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 14})
+	view := ansi.Strip(updated.(Model).View())
+
+	for _, entry := range []string{"/ filter", "q quit", "enter activate"} {
+		if got := strings.Count(view, entry); got != 1 {
+			t.Errorf("%q aparece %d veces en la vista, quería 1:\n%s", entry, got, view)
+		}
+	}
+}


### PR DESCRIPTION
Fifth and final batch of Phase 1 (#13). It picks up the two issues found **during** the phase but left unassigned because they weren't planned.

## Scope

- [x] #21 — The TUI help bar repeats "/ filter" and "q quit"
- [x] #16 — Consider `golangci-lint` in CI

## #21 — TUI help

```
before:  ↑/k up • ↓/j down • enter activate • / filter • q quit • / filter • q quit • ? more
now:     ↑/k up • ↓/j down • enter activate • / filter • q quit • ? more
```

`list.Model.ShortHelp` interleaves the delegate's bindings between the cursor keys and its own `KeyMap`, which already provides `Filter` and `Quit`. The delegate declared all three, so two arrived from both sides. It now declares only `enter`, the only one that belongs to it.

No behavior change: these declarations only feed the help renderer. Tests in both states, because `list` omits the delegate's `ShortHelp` while filtering and the bar changes shape there.

## #16 — golangci-lint

An explicit, small set — `errcheck`, `ineffassign`, `unused`, `gosec` — instead of the default one. `staticcheck` is left for a separate PR: it's the noisiest out of the box and its triage shouldn't be mixed in with the rest.

**It earned its place on the first pass: 21 findings.**

### The real ones

**Credential directories at 0755.** This is the finding that justifies the linter on its own. `az` protects its token cache at 0600, but leaves files like `azureProfile.json`, `az.sess` and `msal_http_cache.bin` at **0644**:

```
-rw-r--r--  azureProfile.json
-rw-r--r--  az.sess
-rw-r--r--  msal_http_cache.bin
-rw-------  msal_token_cache.json
```

With the directory at 0755, any other user on the machine can read them. The directory bit is the only lever azsel has. Now **0700**, only at creation: silently changing the permissions of a directory the user already has is more surprise than benefit.

**`config.json` at 0600**, with `Chmod` for the same reason the switch file carries one. It decides which directory ends up in `AZURE_CONFIG_DIR`, so whoever can write it chooses what the shell sources.

**`init` did `defer f.Close()` on a freshly written file.** A `Close` that fails there can mean the append never reached disk, and the user would be told their shell was configured when it wasn't. It's now checked.

**Pruning discarded the error from `os.Remove` implicitly.** It's deliberate and now says so with an explicit blank assignment.

### The exclusions, with the reason in the file rather than a bare `nolint`

| Exclusion | Reason |
|---|---|
| `G204` in `internal/azure` | Running `az` with variable arguments is the package's whole reason for being. The binary is constant and the arguments go as argv elements, not through a shell |
| `G304` in `config.go` and `init.go` | The paths come from azsel's `BaseDir()`, or from the user's own `$SHELL` and `$HOME` |
| `G302` in `init.go` | 0644 is the convention for a shell rc, and `O_CREATE` only applies permissions if the file doesn't exist |
| `errcheck` on `fmt.Fprint*` | All visible output goes to stderr, and the `list` table goes through a tabwriter whose `Flush()` *is* checked |
| `gosec` in `_test.go` | The tests set specific permissions on purpose; in several cases the permission **is** what's being tested |

### CI

New `lint` job with `golangci-lint-action@v9` and pinned version `v2.12.2`. Blocking from day one, as the issue recommended.
