### PR TITLE
Phase 2 — Default tenant via symlink

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,25 @@ jobs:
 
       - run: go test -race ./...
 
+  integration:
+    name: Integration (real az)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # GitHub's Linux runners ship the Azure CLI. Assert it rather than
+      # assume it, so a runner image that drops az turns this job red instead
+      # of skipping the tests silently.
+      - name: Assert az is present
+        run: az version --output none
+
+      - name: Integration tests
+        run: AZSEL_INTEGRATION=1 go test -run TestIntegration ./internal/config/
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -299,6 +299,12 @@ The suite needs neither Azure nor network access. Tests that touch configuration
 go test -race -cover ./...   # what CI runs
 ```
 
+A few tests exercise the real Azure CLI to pin how `az` resolves the default `~/.azure` symlink. They are opt-in so the default suite stays hermetic (no `az`, no network); run them with:
+
+```bash
+AZSEL_INTEGRATION=1 go test ./internal/config/
+```
+
 ### Build and verify
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -204,18 +204,21 @@ $ azsel
 ```
   Azure Tenants
 
-  * contoso
-    xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+   D contoso
+     xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 
-    fabrikam
-    yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
+  *  fabrikam
+     yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
 
-  enter: activate  /: filter  q: quit
+  enter: activate  d: set default  /: filter  q: quit
 ```
+
+`*` marks the active tenant (this shell), `D` the default tenant (new shells). They can be different tenants, as above.
 
 - Use arrow keys (`↑`/`↓`) or `j`/`k` to navigate
 - Press `/` to fuzzy-search by tenant name or ID
 - Press `Enter` to activate the selected tenant
+- Press `d` to make the selected tenant the default (asks first, since it repoints `~/.azure`)
 - Press `q` or `Ctrl+C` to quit without changing anything
 
 ### Remove a tenant

--- a/README.md
+++ b/README.md
@@ -168,6 +168,31 @@ Tenant                                Name
 yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy  fabrikam
 ```
 
+### Set a default tenant
+
+`azsel use` only changes the tenant in your current shell. To make a tenant the default for **every** new shell — and for anything else that runs `az`, including cron jobs and IDEs — point `~/.azure` at it:
+
+```bash
+$ azsel default contoso
+Default tenant set to "contoso".
+New shells will start on this tenant. Open one to try it,
+or run 'azsel use contoso' to switch this shell now.
+```
+
+This works by making `~/.azure` a symlink to the tenant's profile, so no shell integration is needed for it — a fresh terminal, a script, a scheduled job all pick it up. `azsel use` in a shell still wins over the default for that shell, and a subshell inherits its parent's tenant rather than reverting.
+
+If you already had a real `~/.azure` (an existing `az` session), it is **moved** to a backup under `~/.azsel/backups/`, never deleted:
+
+```bash
+$ azsel default contoso
+Moved your existing ~/.azure to /Users/you/.azsel/backups/azure-20260220-153000
+Default tenant set to "contoso".
+```
+
+Show the current default with `azsel default`, and remove it with `azsel default --clear`, which returns `az` to its own `~/.azure` and tells you where the backup is.
+
+> Changing the default takes effect the next time `az` runs in any shell that has not run `azsel use` — `~/.azure` is resolved fresh each time. Shells where you ran `azsel use` keep their tenant.
+
 ### Switch tenant (interactive TUI)
 
 Run `azsel` with no arguments to launch the interactive selector:
@@ -360,6 +385,9 @@ unset AZSEL_DEBUG
 | `azsel add --device-code` | Add a tenant using device code flow (no browser) |
 | `azsel list` | List all configured tenants |
 | `azsel use <name>` | Activate a tenant by name |
+| `azsel default <name>` | Make a tenant the default for new shells |
+| `azsel default` | Show the current default tenant |
+| `azsel default --clear` | Remove the default |
 | `azsel remove <name>` | Remove a tenant and its config directory |
 | `azsel remove <name> -f` | Remove without confirmation |
 | `azsel --version` | Show the current version |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Azure CLI stores its configuration (auth tokens, default subscription, etc.) in 
         └── ...
 ```
 
-Azure CLI extensions are shared across all profiles via a common `~/.azsel/extensions/` directory (using `AZURE_EXTENSION_DIR`), so you only need to install each extension once.
+Azure CLI extensions are shared across all profiles via a common `~/.azsel/extensions/` directory, so you only need to install each extension once. Each tenant's `cliextensions` is a symlink to it, which means az finds the shared extensions through the filesystem no matter how the tenant is reached — you do not have to set `AZURE_EXTENSION_DIR` yourself.
 
 Those directories are created `0700`, and `config.json` is written `0600`. Azure CLI protects its token cache itself, but leaves `azureProfile.json`, `az.sess` and its HTTP cache world-readable, so the directory bit is the only lever `azsel` has over who else on the machine can read them. Directories that already exist keep the permissions they have.
 
@@ -67,7 +67,7 @@ CI runs the test suite on Linux and macOS, exercising the wrapper under both bas
 
 | Dependency | Requirement |
 |---|---|
-| Azure CLI | Any version honouring `AZURE_CONFIG_DIR` and `AZURE_EXTENSION_DIR`. Verified against 2.87.0; the practical floor is older but has not been pinned down |
+| Azure CLI | Any version honouring `AZURE_CONFIG_DIR`. Verified against 2.87.0; the practical floor is older but has not been pinned down |
 | Go | Only needed to build from source. See `go.mod` for the version in force |
 
 ## Installation
@@ -338,7 +338,6 @@ This outputs trace information to stderr showing:
 Switched to tenant "contoso"
 [azsel-debug] sourcing /Users/you/.azsel/.switch.48231
 export AZURE_CONFIG_DIR=/Users/you/.azsel/tenants/contoso
-export AZURE_EXTENSION_DIR=/Users/you/.azsel/extensions
 [azsel-debug] AZURE_CONFIG_DIR=/Users/you/.azsel/tenants/contoso
 ```
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -110,13 +110,17 @@ func newAddCmd() *cobra.Command {
 				}
 			}()
 
-			extDir, err := config.EnsureExtensionsDir()
-			if err != nil {
+			// Share extensions through the filesystem before az runs, so the
+			// login already reads and writes them in the shared directory
+			// (see #26). Reached through the default link there is no
+			// AZURE_EXTENSION_DIR to steer az, so the symlink is what makes
+			// sharing hold however the tenant is later entered.
+			if err := config.EnsureSharedExtensionsLink(configDir); err != nil {
 				return err
 			}
 
 			fmt.Fprintf(os.Stderr, "\nLogging in to tenant %q (%s)...\n", name, tenantID)
-			if err := azure.Login(tenantID, configDir, extDir, useDeviceCode); err != nil {
+			if err := azure.Login(tenantID, configDir, useDeviceCode); err != nil {
 				return fmt.Errorf("az login failed: %w", err)
 			}
 

--- a/cmd/default.go
+++ b/cmd/default.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/aolmosj/azsel/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func newDefaultCmd() *cobra.Command {
+	var clear bool
+
+	c := &cobra.Command{
+		Use:   "default [name]",
+		Short: "Set, show or clear the default tenant for new shells",
+		Long: `Set the default tenant by pointing ~/.azure at its profile, so every
+new shell — and anything else that runs az, including cron and IDEs —
+starts on that tenant without running azsel first.
+
+  azsel default <name>   make <name> the default
+  azsel default          show the current default
+  azsel default --clear  remove the default, returning az to its own ~/.azure
+
+Setting a default takes over ~/.azure. An existing ~/.azure directory is
+moved to a backup under ~/.azsel/backups first; it is never deleted.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+
+			switch {
+			case clear:
+				if len(args) > 0 {
+					return fmt.Errorf("--clear takes no tenant name")
+				}
+				return runDefaultClear(cfg)
+			case len(args) == 1:
+				return runDefaultSet(cfg, args[0])
+			default:
+				return runDefaultShow(cfg)
+			}
+		},
+	}
+
+	c.Flags().BoolVar(&clear, "clear", false, "Remove the default tenant")
+	return c
+}
+
+func runDefaultSet(cfg *config.Config, name string) error {
+	// The timestamp names the backup directory. It is generated here, in the
+	// command layer, so config stays testable against a fixed clock.
+	stamp := time.Now().Format("20060102-150405")
+	res, err := config.SetDefault(cfg, name, stamp)
+	if err != nil {
+		return err
+	}
+	if res.BackupPath != "" {
+		fmt.Fprintf(os.Stderr, "Moved your existing ~/.azure to %s\n", res.BackupPath)
+	}
+	if res.Repointed {
+		fmt.Fprintf(os.Stderr, "Default tenant is now %q.\n", res.Tenant)
+	} else {
+		fmt.Fprintf(os.Stderr, "Default tenant set to %q.\n", res.Tenant)
+		fmt.Fprintln(os.Stderr, "New shells will start on this tenant. Open one to try it,")
+		fmt.Fprintln(os.Stderr, "or run 'azsel use "+res.Tenant+"' to switch this shell now.")
+	}
+	return nil
+}
+
+func runDefaultClear(cfg *config.Config) error {
+	res, err := config.ClearDefault(cfg)
+	if err != nil {
+		return err
+	}
+	if res.Cleared {
+		fmt.Fprintln(os.Stderr, "Default cleared. az will use its own ~/.azure again.")
+	} else {
+		fmt.Fprintln(os.Stderr, "No default was set.")
+	}
+	if res.LatestBackup != "" {
+		fmt.Fprintf(os.Stderr, "Your previous ~/.azure is at %s\n", res.LatestBackup)
+		fmt.Fprintln(os.Stderr, "Restore it with: rm -rf ~/.azure && mv "+res.LatestBackup+" ~/.azure")
+	}
+	return nil
+}
+
+func runDefaultShow(cfg *config.Config) error {
+	info, err := config.ResolveDefault(cfg)
+	if err != nil {
+		return err
+	}
+	switch info.State {
+	case config.DefaultSet:
+		fmt.Fprintf(os.Stderr, "Default tenant: %s\n", info.Tenant)
+	case config.DefaultNone, config.DefaultNative:
+		fmt.Fprintln(os.Stderr, "No default set. az uses its own ~/.azure.")
+		fmt.Fprintln(os.Stderr, "Set one with: azsel default <name>")
+	case config.DefaultForeign:
+		fmt.Fprintf(os.Stderr, "~/.azure is a symlink to %s, which azsel did not create.\n", info.Target)
+	case config.DefaultBroken:
+		fmt.Fprintf(os.Stderr, "~/.azure is a broken symlink to %s.\n", info.Target)
+		fmt.Fprintln(os.Stderr, "az will fail until this is fixed. Run 'azsel default --clear' to remove it,")
+		fmt.Fprintln(os.Stderr, "or 'azsel default <name>' to point it at a tenant.")
+	}
+	return nil
+}

--- a/cmd/default_test.go
+++ b/cmd/default_test.go
@@ -1,0 +1,168 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aolmosj/azsel/internal/config"
+)
+
+func defaultSandbox(t *testing.T, tenants ...string) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(config.EnvHome, filepath.Join(home, ".azsel"))
+	cfg := &config.Config{}
+	for _, name := range tenants {
+		dir, _, err := config.EnsureTenantDir(name)
+		if err != nil {
+			t.Fatalf("preparando: %v", err)
+		}
+		cfg.Tenants = append(cfg.Tenants, config.Tenant{Name: name, ConfigDir: dir})
+	}
+	if err := config.Save(cfg); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	return home
+}
+
+func TestDefaultSetCreatesLink(t *testing.T) {
+	home := defaultSandbox(t, "contoso")
+	out := quiet(t)
+	if err := run(t, newDefaultCmd(), "contoso"); err != nil {
+		t.Fatalf("default contoso: %v", err)
+	}
+	target, err := os.Readlink(filepath.Join(home, ".azure"))
+	if err != nil {
+		t.Fatalf("~/.azure no es enlace: %v", err)
+	}
+	if !strings.HasSuffix(target, filepath.Join("tenants", "contoso")) {
+		t.Errorf("~/.azure -> %q, quería el tenant contoso", target)
+	}
+	if got := out(); !strings.Contains(got, "Default tenant set") {
+		t.Errorf("salida = %q", got)
+	}
+}
+
+func TestDefaultSetBacksUpRealAzure(t *testing.T) {
+	home := defaultSandbox(t, "contoso")
+	azure := filepath.Join(home, ".azure")
+	if err := os.MkdirAll(azure, 0755); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(azure, "tok"), []byte("x"), 0600); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	out := quiet(t)
+	if err := run(t, newDefaultCmd(), "contoso"); err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	if got := out(); !strings.Contains(got, "Moved your existing ~/.azure") {
+		t.Errorf("no se informó del backup: %q", got)
+	}
+	// El backup existe y conserva el contenido.
+	entries, err := os.ReadDir(filepath.Join(home, ".azsel", "backups"))
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("backups = %v (err %v)", entries, err)
+	}
+}
+
+func TestDefaultShow(t *testing.T) {
+	defaultSandbox(t, "contoso")
+	out := quiet(t)
+	if err := run(t, newDefaultCmd()); err != nil {
+		t.Fatalf("default: %v", err)
+	}
+	if got := out(); !strings.Contains(got, "No default set") {
+		t.Errorf("salida = %q, quería «No default set»", got)
+	}
+}
+
+func TestDefaultShowWhenSet(t *testing.T) {
+	defaultSandbox(t, "contoso")
+	quiet(t)
+	if err := run(t, newDefaultCmd(), "contoso"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	out := quiet(t)
+	if err := run(t, newDefaultCmd()); err != nil {
+		t.Fatalf("show: %v", err)
+	}
+	if got := out(); !strings.Contains(got, "Default tenant: contoso") {
+		t.Errorf("salida = %q", got)
+	}
+}
+
+func TestDefaultClear(t *testing.T) {
+	home := defaultSandbox(t, "contoso")
+	quiet(t)
+	if err := run(t, newDefaultCmd(), "contoso"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	out := quiet(t)
+	if err := run(t, newDefaultCmd(), "--clear"); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".azure")); !os.IsNotExist(err) {
+		t.Error("~/.azure sigue existiendo tras --clear")
+	}
+	if got := out(); !strings.Contains(got, "Default cleared") {
+		t.Errorf("salida = %q", got)
+	}
+}
+
+func TestDefaultClearReportsBackup(t *testing.T) {
+	home := defaultSandbox(t, "contoso")
+	if err := os.MkdirAll(filepath.Join(home, ".azure"), 0755); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	quiet(t)
+	if err := run(t, newDefaultCmd(), "contoso"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	out := quiet(t)
+	if err := run(t, newDefaultCmd(), "--clear"); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	if got := out(); !strings.Contains(got, "Restore it with:") {
+		t.Errorf("clear no explicó cómo restaurar: %q", got)
+	}
+}
+
+func TestDefaultRejectsUnknownTenant(t *testing.T) {
+	defaultSandbox(t, "contoso")
+	quiet(t)
+	if err := run(t, newDefaultCmd(), "fantasma"); err == nil {
+		t.Fatal("default aceptó un tenant inexistente")
+	}
+}
+
+func TestDefaultClearWithNameIsError(t *testing.T) {
+	defaultSandbox(t, "contoso")
+	quiet(t)
+	if err := run(t, newDefaultCmd(), "contoso", "--clear"); err == nil {
+		t.Fatal("default --clear con nombre debería fallar")
+	}
+}
+
+// Mostrar un enlace roto debe explicar el problema, no fingir normalidad.
+func TestDefaultShowBrokenLink(t *testing.T) {
+	home := defaultSandbox(t, "contoso")
+	quiet(t)
+	if err := run(t, newDefaultCmd(), "contoso"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	// Rompemos el enlace borrando el tenant a mano (sin pasar por remove).
+	if err := os.RemoveAll(filepath.Join(home, ".azsel", "tenants", "contoso")); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	out := quiet(t)
+	if err := run(t, newDefaultCmd()); err != nil {
+		t.Fatalf("show: %v", err)
+	}
+	if got := out(); !strings.Contains(got, "broken symlink") {
+		t.Errorf("no se avisó del enlace roto: %q", got)
+	}
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/aolmosj/azsel/internal/config"
@@ -24,16 +25,41 @@ func newListCmd() *cobra.Command {
 				return nil
 			}
 			currentDir := os.Getenv("AZURE_CONFIG_DIR")
+
+			// "active" and "default" are different things: active is the
+			// tenant this shell points at right now, default is the one new
+			// shells will start on. A tenant can be either, both, or neither.
+			def, defErr := config.ResolveDefault(cfg)
+
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-			fmt.Fprintln(w, "ACTIVE\tNAME\tTENANT ID\tCONFIG DIR")
+			fmt.Fprintln(w, "ACTIVE\tDEFAULT\tNAME\tTENANT ID\tCONFIG DIR")
 			for _, t := range cfg.Tenants {
 				active := ""
 				if t.ConfigDir == currentDir {
 					active = "*"
 				}
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", active, t.Name, t.TenantID, t.ConfigDir)
+				isDefault := ""
+				if defErr == nil && def.State == config.DefaultSet && strings.EqualFold(def.Tenant, t.Name) {
+					isDefault = "D"
+				}
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", active, isDefault, t.Name, t.TenantID, t.ConfigDir)
 			}
-			return w.Flush()
+			if err := w.Flush(); err != nil {
+				return err
+			}
+
+			// A broken or foreign ~/.azure never shows as a default above, so
+			// say why here — list is where someone looks when az misbehaves.
+			if defErr == nil {
+				switch def.State {
+				case config.DefaultBroken:
+					fmt.Fprintf(os.Stderr, "\nWarning: ~/.azure is a broken symlink to %s; az will fail until it is fixed.\n", def.Target)
+					fmt.Fprintln(os.Stderr, "Run 'azsel default --clear' or 'azsel default <name>' to repair it.")
+				case config.DefaultForeign:
+					fmt.Fprintf(os.Stderr, "\nNote: ~/.azure is a symlink to %s that azsel did not create.\n", def.Target)
+				}
+			}
+			return nil
 		},
 	}
 }

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aolmosj/azsel/internal/config"
+)
+
+func listSandbox(t *testing.T, tenants ...string) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(config.EnvHome, filepath.Join(home, ".azsel"))
+	cfg := &config.Config{}
+	for _, name := range tenants {
+		dir, _, err := config.EnsureTenantDir(name)
+		if err != nil {
+			t.Fatalf("preparando: %v", err)
+		}
+		cfg.Tenants = append(cfg.Tenants, config.Tenant{Name: name, TenantID: name + "-id", ConfigDir: dir})
+	}
+	if err := config.Save(cfg); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	return home
+}
+
+// list separa activo de default: el activo sale de AZURE_CONFIG_DIR, el
+// default del enlace. Deben poder ser tenants distintos.
+func TestListShowsActiveAndDefaultSeparately(t *testing.T) {
+	home := listSandbox(t, "contoso", "fabrikam")
+	cfg, _ := config.Load()
+	if _, err := config.SetDefault(cfg, "contoso", "20260220-120000"); err != nil {
+		t.Fatalf("SetDefault: %v", err)
+	}
+	// activo = fabrikam, default = contoso
+	t.Setenv("AZURE_CONFIG_DIR", filepath.Join(home, ".azsel", "tenants", "fabrikam"))
+
+	out := quiet(t)
+	if err := run(t, newListCmd()); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	got := out()
+	if !strings.Contains(got, "DEFAULT") {
+		t.Errorf("falta la columna DEFAULT:\n%s", got)
+	}
+	// La línea de contoso lleva D pero no *; la de fabrikam al revés.
+	for _, line := range strings.Split(got, "\n") {
+		if strings.Contains(line, "contoso") && !strings.Contains(line, "D") {
+			t.Errorf("contoso debería marcarse como default: %q", line)
+		}
+		if strings.Contains(line, "fabrikam") && !strings.HasPrefix(strings.TrimSpace(line), "*") {
+			t.Errorf("fabrikam debería marcarse como activo: %q", line)
+		}
+	}
+}
+
+func TestListWarnsOnBrokenDefault(t *testing.T) {
+	home := listSandbox(t, "contoso")
+	cfg, _ := config.Load()
+	if _, err := config.SetDefault(cfg, "contoso", "20260220-120000"); err != nil {
+		t.Fatalf("SetDefault: %v", err)
+	}
+	// Rompemos el enlace borrando el destino a mano.
+	if err := os.RemoveAll(filepath.Join(home, ".azsel", "tenants", "contoso")); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	out := quiet(t)
+	if err := run(t, newListCmd()); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if got := out(); !strings.Contains(got, "broken symlink") {
+		t.Errorf("list no avisó del enlace roto:\n%s", got)
+	}
+}
+
+func TestListNoDefault(t *testing.T) {
+	listSandbox(t, "contoso")
+	out := quiet(t)
+	if err := run(t, newListCmd()); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	got := out()
+	if !strings.Contains(got, "DEFAULT") {
+		t.Errorf("la cabecera DEFAULT debe estar siempre:\n%s", got)
+	}
+	// Sin default, ninguna línea de tenant lleva la D marcada.
+	for _, line := range strings.Split(got, "\n") {
+		if strings.Contains(line, "contoso") && strings.Contains(strings.Fields(line)[0], "D") {
+			t.Errorf("contoso marcado como default sin haberlo fijado: %q", line)
+		}
+	}
+}

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -40,6 +40,21 @@ func newRemoveCmd() *cobra.Command {
 			}
 
 			configDir := tenant.ConfigDir
+
+			// If this tenant is the default, drop the ~/.azure link before
+			// anything else. Removing the directory first would leave the
+			// link dangling, and az fails hard on a dangling ~/.azure. This
+			// has to happen while the tenant is still in the config, or
+			// ClearDefault would read the link as one it does not own and
+			// refuse to touch it.
+			if info, err := config.ResolveDefault(cfg); err == nil &&
+				info.State == config.DefaultSet && strings.EqualFold(info.Tenant, name) {
+				if _, err := config.ClearDefault(cfg); err != nil {
+					return fmt.Errorf("clearing default before removal: %w", err)
+				}
+				fmt.Fprintf(os.Stderr, "Cleared default (was %q).\n", name)
+			}
+
 			if err := cfg.RemoveTenant(name); err != nil {
 				return err
 			}

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -41,14 +41,19 @@ func newRemoveCmd() *cobra.Command {
 
 			configDir := tenant.ConfigDir
 
-			// If this tenant is the default, drop the ~/.azure link before
-			// anything else. Removing the directory first would leave the
-			// link dangling, and az fails hard on a dangling ~/.azure. This
-			// has to happen while the tenant is still in the config, or
-			// ClearDefault would read the link as one it does not own and
-			// refuse to touch it.
-			if info, err := config.ResolveDefault(cfg); err == nil &&
-				info.State == config.DefaultSet && strings.EqualFold(info.Tenant, name) {
+			// If ~/.azure points at this tenant, drop the link before removing
+			// the directory — deleting it first would leave ~/.azure dangling,
+			// and az fails hard on that. Keyed on the link target rather than
+			// on ResolveDefault's state so it also catches an already-dangling
+			// link into this tenant (the DefaultBroken case). Done while the
+			// tenant is still in the config, or ClearDefault would read the
+			// link as one it does not own and refuse it.
+			switch target, err := config.DefaultLinkTarget(); {
+			case err != nil:
+				// Could not read the link. Surface it rather than delete
+				// blindly and risk a silent dangle.
+				fmt.Fprintf(os.Stderr, "Warning: could not check the default link: %v\n", err)
+			case target == tenant.ConfigDir:
 				if _, err := config.ClearDefault(cfg); err != nil {
 					return fmt.Errorf("clearing default before removal: %w", err)
 				}

--- a/cmd/remove_default_test.go
+++ b/cmd/remove_default_test.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aolmosj/azsel/internal/config"
+)
+
+// removeSandbox isolates ~/.azsel and ~/.azure and returns the fake home.
+func removeSandbox(t *testing.T, tenants ...string) (home string, cfg *config.Config) {
+	t.Helper()
+	home = t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(config.EnvHome, filepath.Join(home, ".azsel"))
+	cfg = &config.Config{}
+	for _, name := range tenants {
+		dir, _, err := config.EnsureTenantDir(name)
+		if err != nil {
+			t.Fatalf("preparando: %v", err)
+		}
+		cfg.Tenants = append(cfg.Tenants, config.Tenant{Name: name, ConfigDir: dir})
+	}
+	if err := config.Save(cfg); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	return home, cfg
+}
+
+// Borrar el tenant por defecto debe eliminar el enlace ANTES de borrar el
+// directorio; si no, ~/.azure queda colgando y az revienta.
+func TestRemoveDefaultTenantClearsLink(t *testing.T) {
+	home, cfg := removeSandbox(t, "contoso")
+	if _, err := config.SetDefault(cfg, "contoso", "20260220-120000"); err != nil {
+		t.Fatalf("SetDefault: %v", err)
+	}
+	quiet(t)
+
+	if err := run(t, newRemoveCmd(), "contoso", "-f"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	// El enlace no debe quedar, ni colgando ni de ningún tipo.
+	if _, err := os.Lstat(filepath.Join(home, ".azure")); !os.IsNotExist(err) {
+		t.Errorf("~/.azure sigue existiendo tras borrar el tenant por defecto (err=%v)", err)
+	}
+	// Y el tenant desapareció del config.
+	reloaded, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if reloaded.FindTenant("contoso") != nil {
+		t.Error("el tenant sigue en config.json")
+	}
+}
+
+// Borrar un tenant que NO es el default deja el enlace intacto.
+func TestRemoveNonDefaultTenantLeavesLink(t *testing.T) {
+	home, cfg := removeSandbox(t, "contoso", "fabrikam")
+	if _, err := config.SetDefault(cfg, "contoso", "20260220-120000"); err != nil {
+		t.Fatalf("SetDefault: %v", err)
+	}
+	quiet(t)
+
+	if err := run(t, newRemoveCmd(), "fabrikam", "-f"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	// El enlace a contoso sigue vivo y apuntando bien.
+	got, err := os.Readlink(filepath.Join(home, ".azure"))
+	if err != nil {
+		t.Fatalf("el enlace del default desapareció: %v", err)
+	}
+	if want := cfg.FindTenant("contoso").ConfigDir; got != want {
+		t.Errorf("~/.azure -> %q, quería %q", got, want)
+	}
+}

--- a/cmd/remove_default_test.go
+++ b/cmd/remove_default_test.go
@@ -76,3 +76,27 @@ func TestRemoveNonDefaultTenantLeavesLink(t *testing.T) {
 		t.Errorf("~/.azure -> %q, quería %q", got, want)
 	}
 }
+
+// Bug del review: si el enlace del default ya está roto (el tenant borrado a
+// mano) y luego se hace `azsel remove`, el enlace quedaba colgando porque el
+// guard solo miraba DefaultSet, no DefaultBroken.
+func TestRemoveTenantWithAlreadyBrokenDefaultLink(t *testing.T) {
+	home, cfg := removeSandbox(t, "contoso")
+	if _, err := config.SetDefault(cfg, "contoso", "20260220-120000"); err != nil {
+		t.Fatalf("SetDefault: %v", err)
+	}
+	// Rompemos el enlace borrando el directorio del tenant a mano — ahora
+	// ~/.azure es un enlace colgando hacia contoso.
+	if err := os.RemoveAll(filepath.Join(home, ".azsel", "tenants", "contoso")); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	quiet(t)
+
+	if err := run(t, newRemoveCmd(), "contoso", "-f"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	// El enlace roto no debe sobrevivir a la eliminación.
+	if _, err := os.Lstat(filepath.Join(home, ".azure")); !os.IsNotExist(err) {
+		t.Errorf("~/.azure sigue existiendo (colgando) tras borrar el tenant (err=%v)", err)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,7 @@ func init() {
 	rootCmd.AddCommand(newUseCmd())
 	rootCmd.AddCommand(newRemoveCmd())
 	rootCmd.AddCommand(newInitCmd())
+	rootCmd.AddCommand(newDefaultCmd())
 }
 
 func Execute() error {

--- a/cmd/tui.go
+++ b/cmd/tui.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/aolmosj/azsel/internal/config"
 	"github.com/aolmosj/azsel/internal/tui"
@@ -28,7 +29,12 @@ func runTUI(cmd *cobra.Command, args []string) error {
 	if def, err := config.ResolveDefault(cfg); err == nil && def.State == config.DefaultSet {
 		defaultName = def.Tenant
 	}
-	model := tui.NewModel(cfg.Tenants, currentDir, defaultName)
+	setDefault := func(name string) error {
+		stamp := time.Now().Format("20060102-150405")
+		_, err := config.SetDefault(cfg, name, stamp)
+		return err
+	}
+	model := tui.NewModel(cfg.Tenants, currentDir, defaultName, setDefault)
 
 	p := tea.NewProgram(model, tea.WithOutput(os.Stderr))
 	finalModel, err := p.Run()

--- a/cmd/tui.go
+++ b/cmd/tui.go
@@ -21,7 +21,14 @@ func runTUI(cmd *cobra.Command, args []string) error {
 	}
 
 	currentDir := os.Getenv("AZURE_CONFIG_DIR")
-	model := tui.NewModel(cfg.Tenants, currentDir)
+	// The default is a filesystem fact (the ~/.azure symlink); resolving it
+	// can fail on a genuinely broken filesystem, in which case the TUI simply
+	// shows no default marker rather than refusing to open.
+	defaultName := ""
+	if def, err := config.ResolveDefault(cfg); err == nil && def.State == config.DefaultSet {
+		defaultName = def.Tenant
+	}
+	model := tui.NewModel(cfg.Tenants, currentDir, defaultName)
 
 	p := tea.NewProgram(model, tea.WithOutput(os.Stderr))
 	finalModel, err := p.Run()

--- a/cmd/tui.go
+++ b/cmd/tui.go
@@ -31,11 +31,10 @@ func runTUI(cmd *cobra.Command, args []string) error {
 
 	if m, ok := finalModel.(tui.Model); ok {
 		if selected := m.Selected(); selected != nil {
-			extDir, err := config.EnsureExtensionsDir()
-			if err != nil {
+			if err := config.EnsureSharedExtensionsLink(selected.ConfigDir); err != nil {
 				return err
 			}
-			exports := fmt.Sprintf("export AZURE_CONFIG_DIR=%s\nexport AZURE_EXTENSION_DIR=%s\n", selected.ConfigDir, extDir)
+			exports := fmt.Sprintf("export AZURE_CONFIG_DIR=%s\n", selected.ConfigDir)
 			if err := config.WriteEnv(exports); err != nil {
 				return err
 			}

--- a/cmd/tui.go
+++ b/cmd/tui.go
@@ -29,10 +29,16 @@ func runTUI(cmd *cobra.Command, args []string) error {
 	if def, err := config.ResolveDefault(cfg); err == nil && def.State == config.DefaultSet {
 		defaultName = def.Tenant
 	}
-	setDefault := func(name string) error {
+	setDefault := func(name string) (string, error) {
 		stamp := time.Now().Format("20060102-150405")
-		_, err := config.SetDefault(cfg, name, stamp)
-		return err
+		res, err := config.SetDefault(cfg, name, stamp)
+		if err != nil {
+			return "", err
+		}
+		if res.BackupPath != "" {
+			return "Moved your existing ~/.azure to " + res.BackupPath, nil
+		}
+		return "", nil
 	}
 	model := tui.NewModel(cfg.Tenants, currentDir, defaultName, setDefault)
 

--- a/cmd/use.go
+++ b/cmd/use.go
@@ -25,11 +25,13 @@ func newUseCmd() *cobra.Command {
 			if _, err := os.Stat(tenant.ConfigDir); os.IsNotExist(err) {
 				return fmt.Errorf("config directory %s does not exist — try running 'azsel add' again", tenant.ConfigDir)
 			}
-			extDir, err := config.EnsureExtensionsDir()
-			if err != nil {
+			// Keep the tenant sharing extensions through its cliextensions
+			// symlink. Idempotent and cheap, and it migrates tenants created
+			// before this became a filesystem fact.
+			if err := config.EnsureSharedExtensionsLink(tenant.ConfigDir); err != nil {
 				return err
 			}
-			exports := fmt.Sprintf("export AZURE_CONFIG_DIR=%s\nexport AZURE_EXTENSION_DIR=%s\n", tenant.ConfigDir, extDir)
+			exports := fmt.Sprintf("export AZURE_CONFIG_DIR=%s\n", tenant.ConfigDir)
 			if err := config.WriteEnv(exports); err != nil {
 				return err
 			}

--- a/internal/azure/azure.go
+++ b/internal/azure/azure.go
@@ -36,30 +36,28 @@ func Available() error {
 	return nil
 }
 
-// command builds an az invocation scoped to one tenant's directories. The
-// environment is inherited so az keeps the user's proxy, locale and so on;
-// only the two directories azsel controls are overridden.
+// command builds an az invocation scoped to one tenant's config directory.
+// The environment is inherited so az keeps the user's proxy, locale and so
+// on; only AZURE_CONFIG_DIR is overridden.
 //
-// Those two may already be exported — by azsel itself in an active session,
-// or by an Azure CLI install that sets AZURE_EXTENSION_DIR system-wide. That
-// is fine: os/exec deduplicates Env keeping the last occurrence, so what is
-// appended here wins. TestCommandEnvOverridesInheritedValues pins it, because
-// the guarantee is not obvious from reading this.
-func command(configDir, extensionsDir string, args ...string) *exec.Cmd {
+// Extensions are no longer steered with AZURE_EXTENSION_DIR: each tenant's
+// cliextensions is a symlink to the shared directory, so az finds shared
+// extensions through the filesystem however the tenant is reached (see
+// config.EnsureSharedExtensionsLink). AZURE_CONFIG_DIR may already be exported
+// — by azsel itself in an active session — and that is fine: os/exec
+// deduplicates Env keeping the last occurrence, so what is appended here wins.
+func command(configDir string, args ...string) *exec.Cmd {
 	cmd := exec.Command(binary, args...)
-	cmd.Env = append(os.Environ(),
-		"AZURE_CONFIG_DIR="+configDir,
-		"AZURE_EXTENSION_DIR="+extensionsDir,
-	)
+	cmd.Env = append(os.Environ(), "AZURE_CONFIG_DIR="+configDir)
 	return cmd
 }
 
-func Login(tenantID, configDir, extensionsDir string, useDeviceCode bool) error {
+func Login(tenantID, configDir string, useDeviceCode bool) error {
 	args := []string{"login", "--tenant", tenantID}
 	if useDeviceCode {
 		args = append(args, "--use-device-code")
 	}
-	cmd := command(configDir, extensionsDir, args...)
+	cmd := command(configDir, args...)
 	// Deliberate, and easy to undo by accident: the login is interactive, so
 	// stdin must reach az; and az's stdout is sent to stderr because azsel
 	// keeps stdout clean for the shell to consume.

--- a/internal/azure/azure_test.go
+++ b/internal/azure/azure_test.go
@@ -85,10 +85,18 @@ func TestLoginScopesTheEnvironment(t *testing.T) {
 	if v, ok := envValue(got.cmd, "AZURE_CONFIG_DIR"); !ok || v != "/cfg/acme" {
 		t.Errorf("AZURE_CONFIG_DIR = %q (presente=%v), quería «/cfg/acme»", v, ok)
 	}
-	// AZURE_EXTENSION_DIR ya no se inyecta: las extensiones se comparten vía
-	// el symlink cliextensions del tenant.
-	if _, ok := envValue(got.cmd, "AZURE_EXTENSION_DIR"); ok {
-		t.Error("AZURE_EXTENSION_DIR sigue inyectándose; debía retirarse")
+
+	// azsel debe añadir EXACTAMENTE una variable al entorno heredado:
+	// AZURE_CONFIG_DIR. Comprobar "AZURE_EXTENSION_DIR ausente" sería falso en
+	// un runner que ya la trae exportada (el de Linux lo hace) — lo que
+	// importa es que azsel no la ponga. command() hace append sobre
+	// os.Environ(), así que lo añadido es la cola tras esa longitud.
+	added := got.cmd.Env[len(os.Environ()):]
+	if len(added) != 1 {
+		t.Fatalf("azsel añadió %d variables, quería 1: %v", len(added), added)
+	}
+	if !strings.HasPrefix(added[0], "AZURE_CONFIG_DIR=") {
+		t.Errorf("azsel añadió %q, quería solo AZURE_CONFIG_DIR", added[0])
 	}
 
 	// El resto del entorno se hereda: az necesita proxy, locale, HOME...

--- a/internal/azure/azure_test.go
+++ b/internal/azure/azure_test.go
@@ -65,7 +65,7 @@ func TestLoginArguments(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			got := stubRun(t, nil)
-			if err := Login("TID", "/cfg", "/ext", c.deviceCode); err != nil {
+			if err := Login("TID", "/cfg", c.deviceCode); err != nil {
 				t.Fatalf("Login: %v", err)
 			}
 			if !slices.Equal(got.cmd.Args, c.want) {
@@ -78,17 +78,17 @@ func TestLoginArguments(t *testing.T) {
 // El aislamiento entre tenants depende enteramente de estas dos variables.
 func TestLoginScopesTheEnvironment(t *testing.T) {
 	got := stubRun(t, nil)
-	if err := Login("TID", "/cfg/acme", "/ext", false); err != nil {
+	if err := Login("TID", "/cfg/acme", false); err != nil {
 		t.Fatalf("Login: %v", err)
 	}
 
-	for _, c := range []struct{ key, want string }{
-		{"AZURE_CONFIG_DIR", "/cfg/acme"},
-		{"AZURE_EXTENSION_DIR", "/ext"},
-	} {
-		if v, ok := envValue(got.cmd, c.key); !ok || v != c.want {
-			t.Errorf("%s = %q (presente=%v), quería %q", c.key, v, ok, c.want)
-		}
+	if v, ok := envValue(got.cmd, "AZURE_CONFIG_DIR"); !ok || v != "/cfg/acme" {
+		t.Errorf("AZURE_CONFIG_DIR = %q (presente=%v), quería «/cfg/acme»", v, ok)
+	}
+	// AZURE_EXTENSION_DIR ya no se inyecta: las extensiones se comparten vía
+	// el symlink cliextensions del tenant.
+	if _, ok := envValue(got.cmd, "AZURE_EXTENSION_DIR"); ok {
+		t.Error("AZURE_EXTENSION_DIR sigue inyectándose; debía retirarse")
 	}
 
 	// El resto del entorno se hereda: az necesita proxy, locale, HOME...
@@ -102,7 +102,7 @@ func TestLoginScopesTheEnvironment(t *testing.T) {
 // porque azsel mantiene stdout limpio para el shell.
 func TestLoginWiresStreams(t *testing.T) {
 	got := stubRun(t, nil)
-	if err := Login("TID", "/cfg", "/ext", false); err != nil {
+	if err := Login("TID", "/cfg", false); err != nil {
 		t.Fatalf("Login: %v", err)
 	}
 	if got.cmd.Stdin != os.Stdin {
@@ -120,7 +120,7 @@ func TestLoginPropagatesFailure(t *testing.T) {
 	want := errors.New("el usuario canceló")
 	stubRun(t, func(*exec.Cmd) error { return want })
 
-	err := Login("TID", "/cfg", "/ext", false)
+	err := Login("TID", "/cfg", false)
 	if !errors.Is(err, want) {
 		t.Errorf("error = %v, quería %v", err, want)
 	}
@@ -168,19 +168,13 @@ func TestAvailable(t *testing.T) {
 // azsel appends has to win.
 func TestCommandEnvOverridesInheritedValues(t *testing.T) {
 	t.Setenv("AZURE_CONFIG_DIR", "/heredado/config")
-	t.Setenv("AZURE_EXTENSION_DIR", "/heredado/extensions")
 
 	got := stubRun(t, nil)
-	if err := Login("TID", "/cfg/acme", "/ext/compartido", false); err != nil {
+	if err := Login("TID", "/cfg/acme", false); err != nil {
 		t.Fatalf("Login: %v", err)
 	}
 
-	for _, c := range []struct{ key, want string }{
-		{"AZURE_CONFIG_DIR", "/cfg/acme"},
-		{"AZURE_EXTENSION_DIR", "/ext/compartido"},
-	} {
-		if v, _ := envValue(got.cmd, c.key); v != c.want {
-			t.Errorf("%s efectivo = %q, quería %q", c.key, v, c.want)
-		}
+	if v, _ := envValue(got.cmd, "AZURE_CONFIG_DIR"); v != "/cfg/acme" {
+		t.Errorf("AZURE_CONFIG_DIR efectivo = %q, quería «/cfg/acme»", v)
 	}
 }

--- a/internal/azure/azure_test.go
+++ b/internal/azure/azure_test.go
@@ -77,6 +77,11 @@ func TestLoginArguments(t *testing.T) {
 
 // El aislamiento entre tenants depende enteramente de estas dos variables.
 func TestLoginScopesTheEnvironment(t *testing.T) {
+	// One snapshot of the environment, taken here, is the baseline for both
+	// what command() inherits and what the test measures — reading
+	// os.Environ() a second time to slice the result could drift (or panic)
+	// if anything mutated the environment in between.
+	base := os.Environ()
 	got := stubRun(t, nil)
 	if err := Login("TID", "/cfg/acme", false); err != nil {
 		t.Fatalf("Login: %v", err)
@@ -86,20 +91,19 @@ func TestLoginScopesTheEnvironment(t *testing.T) {
 		t.Errorf("AZURE_CONFIG_DIR = %q (presente=%v), quería «/cfg/acme»", v, ok)
 	}
 
-	// azsel debe añadir EXACTAMENTE una variable al entorno heredado:
-	// AZURE_CONFIG_DIR. Comprobar "AZURE_EXTENSION_DIR ausente" sería falso en
-	// un runner que ya la trae exportada (el de Linux lo hace) — lo que
-	// importa es que azsel no la ponga. command() hace append sobre
-	// os.Environ(), así que lo añadido es la cola tras esa longitud.
-	added := got.cmd.Env[len(os.Environ()):]
-	if len(added) != 1 {
-		t.Fatalf("azsel añadió %d variables, quería 1: %v", len(added), added)
+	// azsel must add exactly one variable to the inherited environment:
+	// AZURE_CONFIG_DIR. Checking "AZURE_EXTENSION_DIR absent" would be false
+	// on a runner that already exports it (Linux does) — what matters is that
+	// azsel does not set it.
+	if len(got.cmd.Env) < len(base) {
+		t.Fatalf("command() shrank the environment: %d < %d", len(got.cmd.Env), len(base))
 	}
-	if !strings.HasPrefix(added[0], "AZURE_CONFIG_DIR=") {
-		t.Errorf("azsel añadió %q, quería solo AZURE_CONFIG_DIR", added[0])
+	added := got.cmd.Env[len(base):]
+	if len(added) != 1 || added[0] != "AZURE_CONFIG_DIR=/cfg/acme" {
+		t.Errorf("azsel added %v, wanted exactly [AZURE_CONFIG_DIR=/cfg/acme]", added)
 	}
 
-	// El resto del entorno se hereda: az necesita proxy, locale, HOME...
+	// The rest of the environment is inherited: az needs proxy, locale, HOME…
 	if _, ok := envValue(got.cmd, "PATH"); !ok {
 		t.Error("no se heredó el entorno del proceso")
 	}

--- a/internal/config/default.go
+++ b/internal/config/default.go
@@ -195,7 +195,7 @@ func SetDefault(cfg *Config, name string, timestamp string) (SetResult, error) {
 	// Share extensions through the filesystem: the default is reached via the
 	// link with no AZURE_EXTENSION_DIR, so az would otherwise resolve
 	// extensions inside the tenant. See #26.
-	if err := ensureSharedExtensionsLink(tenant.ConfigDir); err != nil {
+	if err := EnsureSharedExtensionsLink(tenant.ConfigDir); err != nil {
 		return SetResult{}, err
 	}
 
@@ -308,11 +308,11 @@ func latestBackup() (string, error) {
 	return filepath.Join(backups, newest), nil
 }
 
-// ensureSharedExtensionsLink makes the tenant's cliextensions a symlink to the
+// EnsureSharedExtensionsLink makes the tenant's cliextensions a symlink to the
 // shared extensions directory, so extensions resolve to the same place
 // whether the tenant is reached through the default link or through
 // AZURE_EXTENSION_DIR. Idempotent: a correct link already in place is left be.
-func ensureSharedExtensionsLink(tenantDir string) error {
+func EnsureSharedExtensionsLink(tenantDir string) error {
 	shared, err := EnsureExtensionsDir()
 	if err != nil {
 		return err

--- a/internal/config/default.go
+++ b/internal/config/default.go
@@ -1,10 +1,12 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 )
 
 // AzureDir is where the Azure CLI keeps its state when AZURE_CONFIG_DIR is
@@ -167,6 +169,15 @@ func SetDefault(cfg *Config, name string, timestamp string) (SetResult, error) {
 	}
 
 	result := SetResult{Tenant: name}
+
+	// Do the extensions link first: it only touches the tenant's own
+	// directory, never ~/.azure. If it were left until after the backup, a
+	// failure here would have already moved a real ~/.azure aside with no new
+	// link in its place — az silently logged out. See review of #26.
+	if err := EnsureSharedExtensionsLink(tenant.ConfigDir); err != nil {
+		return SetResult{}, err
+	}
+
 	switch info.State {
 	case DefaultNone:
 		// Nothing in the way.
@@ -190,13 +201,6 @@ func SetDefault(cfg *Config, name string, timestamp string) (SetResult, error) {
 		result.Repointed = true
 	case DefaultForeign:
 		return SetResult{}, foreignLinkError(azure, info.Target)
-	}
-
-	// Share extensions through the filesystem: the default is reached via the
-	// link with no AZURE_EXTENSION_DIR, so az would otherwise resolve
-	// extensions inside the tenant. See #26.
-	if err := EnsureSharedExtensionsLink(tenant.ConfigDir); err != nil {
-		return SetResult{}, err
 	}
 
 	if err := replaceWithSymlink(tenant.ConfigDir, azure); err != nil {
@@ -276,9 +280,49 @@ func backupAzure(azure, timestamp string) (string, error) {
 	}
 	dest := filepath.Join(backups, "azure-"+timestamp)
 	if err := os.Rename(azure, dest); err != nil {
-		return "", fmt.Errorf("backing up %s to %s: %w", azure, dest, err)
+		// Rename fails across filesystems, which happens when AZSEL_HOME sits
+		// on a different volume than $HOME. Fall back to a copy-then-remove so
+		// the feature still works there, just not instantly.
+		if !errors.Is(err, syscall.EXDEV) {
+			return "", fmt.Errorf("backing up %s to %s: %w", azure, dest, err)
+		}
+		if err := os.CopyFS(dest, os.DirFS(azure)); err != nil {
+			return "", fmt.Errorf("copying %s to %s: %w", azure, dest, err)
+		}
+		if err := os.RemoveAll(azure); err != nil {
+			return "", fmt.Errorf("removing %s after backup: %w", azure, err)
+		}
 	}
 	return dest, nil
+}
+
+// DefaultLinkTarget returns the absolute target of the ~/.azure symlink, or ""
+// when ~/.azure is not a symlink. Unlike ResolveDefault it does not require
+// the target to exist, so it answers "does this link point here?" for a
+// dangling link too — which is what remove needs to avoid leaving a dangle.
+func DefaultLinkTarget() (string, error) {
+	azure, err := AzureDir()
+	if err != nil {
+		return "", err
+	}
+	fi, err := os.Lstat(azure)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		return "", nil
+	}
+	target, err := os.Readlink(azure)
+	if err != nil {
+		return "", err
+	}
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(filepath.Dir(azure), target)
+	}
+	return target, nil
 }
 
 // latestBackup returns the most recent azure-* backup, or an error if none.

--- a/internal/config/default.go
+++ b/internal/config/default.go
@@ -128,3 +128,251 @@ func tenantNameFromTarget(target string) (name string, ok bool, err error) {
 	}
 	return rel, true, nil
 }
+
+// BackupsDir is where azsel parks a ~/.azure it had to move aside. Under
+// ~/.azsel so all of azsel's state lives in one place, computed without
+// creating anything.
+func BackupsDir() (string, error) { return inBase("backups") }
+
+// SetResult reports what SetDefault did, so the caller can tell the user.
+type SetResult struct {
+	Tenant string
+	// BackupPath is set when a real ~/.azure was moved aside; empty otherwise.
+	BackupPath string
+	// Repointed is true when an existing azsel link was moved, false when the
+	// link was created fresh.
+	Repointed bool
+}
+
+// SetDefault makes name the default tenant by pointing ~/.azure at its
+// profile. The symlink is the state; nothing is written to config.json.
+//
+// What happens to an existing ~/.azure follows the policy decided in #29:
+// a real directory is moved to a timestamped backup (never destroyed), an
+// azsel link is repointed, and a link azsel did not create is left alone with
+// an error rather than clobbered.
+func SetDefault(cfg *Config, name string, timestamp string) (SetResult, error) {
+	tenant := cfg.FindTenant(name)
+	if tenant == nil {
+		return SetResult{}, fmt.Errorf("tenant %q not found", name)
+	}
+
+	info, err := ResolveDefault(cfg)
+	if err != nil {
+		return SetResult{}, err
+	}
+	azure, err := AzureDir()
+	if err != nil {
+		return SetResult{}, err
+	}
+
+	result := SetResult{Tenant: name}
+	switch info.State {
+	case DefaultNone:
+		// Nothing in the way.
+	case DefaultSet:
+		result.Repointed = true // our own link; rename replaces it
+	case DefaultNative:
+		backup, err := backupAzure(azure, timestamp)
+		if err != nil {
+			return SetResult{}, err
+		}
+		result.BackupPath = backup
+	case DefaultBroken:
+		// A dangling link is ours to replace only if it pointed into our
+		// tenants directory. One dangling to somewhere else was not put there
+		// by azsel.
+		if under, err := targetUnderTenants(info.Target); err != nil {
+			return SetResult{}, err
+		} else if !under {
+			return SetResult{}, foreignLinkError(azure, info.Target)
+		}
+		result.Repointed = true
+	case DefaultForeign:
+		return SetResult{}, foreignLinkError(azure, info.Target)
+	}
+
+	// Share extensions through the filesystem: the default is reached via the
+	// link with no AZURE_EXTENSION_DIR, so az would otherwise resolve
+	// extensions inside the tenant. See #26.
+	if err := ensureSharedExtensionsLink(tenant.ConfigDir); err != nil {
+		return SetResult{}, err
+	}
+
+	if err := replaceWithSymlink(tenant.ConfigDir, azure); err != nil {
+		return SetResult{}, err
+	}
+	return result, nil
+}
+
+// ClearResult reports what ClearDefault did.
+type ClearResult struct {
+	// Cleared is true when a default link was removed.
+	Cleared bool
+	// LatestBackup is the newest ~/.azure backup on disk, if any, so the
+	// caller can tell the user where their old profile went. Not restored
+	// automatically — with several backups azsel would have to guess which.
+	LatestBackup string
+}
+
+// ClearDefault removes the default link, returning az to its own ~/.azure. A
+// real directory or a foreign link is left untouched.
+func ClearDefault(cfg *Config) (ClearResult, error) {
+	info, err := ResolveDefault(cfg)
+	if err != nil {
+		return ClearResult{}, err
+	}
+	azure, err := AzureDir()
+	if err != nil {
+		return ClearResult{}, err
+	}
+
+	var result ClearResult
+	switch info.State {
+	case DefaultSet:
+		if err := os.Remove(azure); err != nil {
+			return ClearResult{}, fmt.Errorf("removing default link: %w", err)
+		}
+		result.Cleared = true
+	case DefaultBroken:
+		// Only clear a broken link that was ours.
+		under, err := targetUnderTenants(info.Target)
+		if err != nil {
+			return ClearResult{}, err
+		}
+		if under {
+			if err := os.Remove(azure); err != nil {
+				return ClearResult{}, fmt.Errorf("removing default link: %w", err)
+			}
+			result.Cleared = true
+		}
+	case DefaultForeign:
+		return ClearResult{}, foreignLinkError(azure, info.Target)
+	case DefaultNone, DefaultNative:
+		// Nothing azsel put there.
+	}
+
+	if latest, err := latestBackup(); err == nil {
+		result.LatestBackup = latest
+	}
+	return result, nil
+}
+
+func foreignLinkError(azure, target string) error {
+	return fmt.Errorf("%s is a symlink to %s that azsel did not create; "+
+		"refusing to replace it — remove it yourself if you want azsel to manage the default", azure, target)
+}
+
+// backupAzure moves a real ~/.azure into ~/.azsel/backups/azure-<timestamp>
+// and returns the backup path. A move, not a copy: on the same volume it is
+// instant and preserves everything.
+func backupAzure(azure, timestamp string) (string, error) {
+	backups, err := BackupsDir()
+	if err != nil {
+		return "", err
+	}
+	if _, err := ensureDir(backups); err != nil {
+		return "", fmt.Errorf("creating backups directory: %w", err)
+	}
+	dest := filepath.Join(backups, "azure-"+timestamp)
+	if err := os.Rename(azure, dest); err != nil {
+		return "", fmt.Errorf("backing up %s to %s: %w", azure, dest, err)
+	}
+	return dest, nil
+}
+
+// latestBackup returns the most recent azure-* backup, or an error if none.
+func latestBackup() (string, error) {
+	backups, err := BackupsDir()
+	if err != nil {
+		return "", err
+	}
+	entries, err := os.ReadDir(backups)
+	if err != nil {
+		return "", err
+	}
+	var newest string
+	for _, e := range entries {
+		if !strings.HasPrefix(e.Name(), "azure-") {
+			continue
+		}
+		// Names are azure-<timestamp>; lexical order matches chronological
+		// when the caller uses a sortable timestamp.
+		if e.Name() > newest {
+			newest = e.Name()
+		}
+	}
+	if newest == "" {
+		return "", fmt.Errorf("no backups")
+	}
+	return filepath.Join(backups, newest), nil
+}
+
+// ensureSharedExtensionsLink makes the tenant's cliextensions a symlink to the
+// shared extensions directory, so extensions resolve to the same place
+// whether the tenant is reached through the default link or through
+// AZURE_EXTENSION_DIR. Idempotent: a correct link already in place is left be.
+func ensureSharedExtensionsLink(tenantDir string) error {
+	shared, err := EnsureExtensionsDir()
+	if err != nil {
+		return err
+	}
+	link := filepath.Join(tenantDir, "cliextensions")
+
+	fi, err := os.Lstat(link)
+	switch {
+	case err == nil && fi.Mode()&os.ModeSymlink != 0:
+		if target, _ := os.Readlink(link); target == shared {
+			return nil // already correct
+		}
+		if err := os.Remove(link); err != nil {
+			return fmt.Errorf("replacing extensions link: %w", err)
+		}
+	case err == nil:
+		// A real directory of stale extensions (leftovers predating the
+		// shared dir). Move it aside rather than delete, then link.
+		if err := os.Rename(link, link+".bak"); err != nil {
+			return fmt.Errorf("moving aside stale extensions: %w", err)
+		}
+	case !os.IsNotExist(err):
+		return fmt.Errorf("inspecting %s: %w", link, err)
+	}
+
+	if err := os.Symlink(shared, link); err != nil {
+		return fmt.Errorf("linking extensions: %w", err)
+	}
+	return nil
+}
+
+// replaceWithSymlink points linkPath at target atomically: it creates the new
+// link under a temporary name and renames it over linkPath, which on POSIX
+// replaces an existing file or symlink in one step, leaving no window where
+// linkPath is missing. It assumes linkPath is absent or a symlink — a real
+// directory there must be moved away first (rename cannot replace a
+// directory), which SetDefault does via backupAzure.
+func replaceWithSymlink(target, linkPath string) error {
+	tmp := fmt.Sprintf("%s.azsel-tmp.%d", linkPath, os.Getpid())
+	// Clear any leftover from an interrupted run.
+	_ = os.Remove(tmp)
+	if err := os.Symlink(target, tmp); err != nil {
+		return fmt.Errorf("creating link: %w", err)
+	}
+	if err := os.Rename(tmp, linkPath); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("installing link at %s: %w", linkPath, err)
+	}
+	return nil
+}
+
+// targetUnderTenants reports whether a path lies inside the tenants directory.
+func targetUnderTenants(target string) (bool, error) {
+	tenants, err := TenantsDir()
+	if err != nil {
+		return false, err
+	}
+	rel, err := filepath.Rel(tenants, target)
+	if err != nil {
+		return false, nil
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)), nil
+}

--- a/internal/config/default.go
+++ b/internal/config/default.go
@@ -1,0 +1,130 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// AzureDir is where the Azure CLI keeps its state when AZURE_CONFIG_DIR is
+// unset: ~/.azure. The default-tenant mechanism turns this path into a
+// symlink, so azsel needs to name it. It hangs off $HOME, not AZSEL_HOME —
+// az knows nothing about the latter — which tests must keep in mind: they
+// control both.
+func AzureDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("getting home directory: %w", err)
+	}
+	return filepath.Join(home, ".azure"), nil
+}
+
+// DefaultState classifies what ~/.azure currently is. The default tenant is
+// not stored anywhere — the symlink is the only source of truth — so reading
+// it means inspecting that path.
+type DefaultState int
+
+const (
+	// DefaultNone: ~/.azure does not exist. az will create its own directory
+	// on first use. No default is set.
+	DefaultNone DefaultState = iota
+	// DefaultNative: ~/.azure is a real directory — az's own profile,
+	// untouched by azsel. No default is set.
+	DefaultNative
+	// DefaultSet: ~/.azure is a symlink into ~/.azsel/tenants/<name> for a
+	// tenant azsel knows. That tenant is the default.
+	DefaultSet
+	// DefaultForeign: ~/.azure is a symlink, but not to a tenant azsel
+	// manages. Someone else set it up; azsel must not touch it.
+	DefaultForeign
+	// DefaultBroken: ~/.azure is a symlink whose target is gone. az fails
+	// with a stack trace until this is repaired, so it has to be surfaced.
+	DefaultBroken
+)
+
+// DefaultInfo is the resolved state of the default tenant.
+type DefaultInfo struct {
+	State DefaultState
+	// Tenant is the default tenant's name, set only when State is DefaultSet.
+	Tenant string
+	// Target is the symlink's destination, set for every symlink state
+	// (DefaultSet, DefaultForeign, DefaultBroken) for diagnostics.
+	Target string
+}
+
+// ResolveDefault inspects ~/.azure and reports which tenant, if any, is the
+// default. cfg is needed to tell a known tenant from an unknown one.
+func ResolveDefault(cfg *Config) (DefaultInfo, error) {
+	azure, err := AzureDir()
+	if err != nil {
+		return DefaultInfo{}, err
+	}
+
+	// Lstat, not Stat: Stat would follow the link and a symlink to a real
+	// directory would be indistinguishable from a real directory.
+	fi, err := os.Lstat(azure)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return DefaultInfo{State: DefaultNone}, nil
+		}
+		return DefaultInfo{}, fmt.Errorf("inspecting %s: %w", azure, err)
+	}
+
+	if fi.Mode()&os.ModeSymlink == 0 {
+		return DefaultInfo{State: DefaultNative}, nil
+	}
+
+	target, err := os.Readlink(azure)
+	if err != nil {
+		return DefaultInfo{}, fmt.Errorf("reading link %s: %w", azure, err)
+	}
+	// Resolve to an absolute path so the comparisons below hold even when the
+	// link was written relative.
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(filepath.Dir(azure), target)
+	}
+	info := DefaultInfo{Target: target}
+
+	// A dangling link is dangerous, so it is checked before anything else:
+	// az breaks outright on it.
+	if _, err := os.Stat(target); err != nil {
+		if os.IsNotExist(err) {
+			info.State = DefaultBroken
+			return info, nil
+		}
+		return DefaultInfo{}, fmt.Errorf("resolving link target %s: %w", target, err)
+	}
+
+	name, ok, err := tenantNameFromTarget(target)
+	if err != nil {
+		return DefaultInfo{}, err
+	}
+	if ok && cfg.FindTenant(name) != nil {
+		info.State = DefaultSet
+		info.Tenant = name
+		return info, nil
+	}
+	info.State = DefaultForeign
+	return info, nil
+}
+
+// tenantNameFromTarget returns the tenant name when target is a direct child
+// of the tenants directory, i.e. ~/.azsel/tenants/<name>. A link pointing
+// deeper, or outside, is not one of azsel's tenant directories.
+func tenantNameFromTarget(target string) (name string, ok bool, err error) {
+	tenants, err := TenantsDir()
+	if err != nil {
+		return "", false, err
+	}
+	rel, err := filepath.Rel(tenants, target)
+	if err != nil {
+		// Different volumes on Windows; never a child here.
+		return "", false, nil
+	}
+	// A direct child has no separator and is not "." or "..".
+	if rel == "." || rel == ".." || strings.ContainsRune(rel, filepath.Separator) || strings.HasPrefix(rel, "..") {
+		return "", false, nil
+	}
+	return rel, true, nil
+}

--- a/internal/config/default_integration_test.go
+++ b/internal/config/default_integration_test.go
@@ -1,0 +1,109 @@
+package config_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/aolmosj/azsel/internal/config"
+)
+
+// These tests run the real Azure CLI to pin the behaviours the whole default
+// mechanism rests on: az follows the ~/.azure symlink, AZURE_CONFIG_DIR still
+// overrides it, and with no default az uses its own directory. They were
+// verified by hand while designing #23; here they become a guard against a
+// future az — or a future azsel change — breaking a claim silently.
+//
+// They are opt-in rather than skip-if-absent, so a CI runner that happens not
+// to ship az cannot let them pass as green by skipping (the mistake #18 fixed
+// for the shell tests). Run them with:
+//
+//	AZSEL_INTEGRATION=1 go test ./internal/config/
+//
+// `az config set` is local — no login, no network.
+func requireAzureCLI(t *testing.T) string {
+	t.Helper()
+	if os.Getenv("AZSEL_INTEGRATION") == "" {
+		t.Skip("integration test; set AZSEL_INTEGRATION=1 to run")
+	}
+	az, err := exec.LookPath("az")
+	if err != nil {
+		t.Fatal("AZSEL_INTEGRATION set but az not found in PATH")
+	}
+	return az
+}
+
+// azConfigSet runs `az config set` with the given HOME and AZURE_CONFIG_DIR
+// (empty to leave it unset), a local write that lands in az's config dir.
+func azConfigSet(t *testing.T, az, home, configDir string) {
+	t.Helper()
+	cmd := exec.Command(az, "config", "set", "core.collect_telemetry=false", "--only-show-errors")
+	env := []string{"HOME=" + home, "PATH=" + os.Getenv("PATH")}
+	if configDir != "" {
+		env = append(env, "AZURE_CONFIG_DIR="+configDir)
+	}
+	cmd.Env = env
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("az config set: %v\n%s", err, out)
+	}
+}
+
+// wrote reports whether az left a config file in dir.
+func wrote(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, "config"))
+	return err == nil
+}
+
+// Core claim: with ~/.azure a symlink to a tenant and no AZURE_CONFIG_DIR, az
+// writes into that tenant. This is also the non-interactive guarantee — no rc
+// is loaded here, yet the default is honoured, because the link is a
+// filesystem fact rather than an environment variable.
+func TestIntegrationAzFollowsDefaultLink(t *testing.T) {
+	az := requireAzureCLI(t)
+	home, cfg := azureSandbox(t, "contoso")
+	if _, err := config.SetDefault(cfg, "contoso", "20260220-120000"); err != nil {
+		t.Fatalf("SetDefault: %v", err)
+	}
+	_ = home
+
+	azConfigSet(t, az, home, "")
+
+	tenant := cfg.FindTenant("contoso").ConfigDir
+	if !wrote(tenant) {
+		t.Error("az no escribió en el tenant por defecto vía el enlace")
+	}
+}
+
+// AZURE_CONFIG_DIR must still win, so azsel use keeps controlling the session.
+func TestIntegrationConfigDirOverridesLink(t *testing.T) {
+	az := requireAzureCLI(t)
+	home, cfg := azureSandbox(t, "contoso", "fabrikam")
+	if _, err := config.SetDefault(cfg, "contoso", "20260220-120000"); err != nil {
+		t.Fatalf("SetDefault: %v", err)
+	}
+
+	other := cfg.FindTenant("fabrikam").ConfigDir
+	azConfigSet(t, az, home, other)
+
+	if !wrote(other) {
+		t.Error("az no respetó AZURE_CONFIG_DIR")
+	}
+	if wrote(cfg.FindTenant("contoso").ConfigDir) {
+		t.Error("az escribió en el default pese a AZURE_CONFIG_DIR; la variable debe ganar")
+	}
+}
+
+// With no default (real ~/.azure), az uses its own directory.
+func TestIntegrationNoDefaultUsesNativeAzure(t *testing.T) {
+	az := requireAzureCLI(t)
+	home, _ := azureSandbox(t)
+	azure := filepath.Join(home, ".azure")
+	if err := os.MkdirAll(azure, 0755); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	azConfigSet(t, az, home, "")
+	if !wrote(azure) {
+		t.Error("az no usó su ~/.azure nativo sin default")
+	}
+}

--- a/internal/config/default_test.go
+++ b/internal/config/default_test.go
@@ -1,0 +1,218 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aolmosj/azsel/internal/config"
+)
+
+// azureSandbox isolates both directories the default mechanism touches:
+// ~/.azsel via AZSEL_HOME, and ~/.azure via HOME. It returns the fake home so
+// a test can build ~/.azure paths under it, and a config with the given
+// tenants already present.
+func azureSandbox(t *testing.T, tenants ...string) (home string, cfg *config.Config) {
+	t.Helper()
+	home = t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(config.EnvHome, filepath.Join(home, ".azsel"))
+
+	cfg = &config.Config{}
+	for _, name := range tenants {
+		dir, _, err := config.EnsureTenantDir(name)
+		if err != nil {
+			t.Fatalf("preparando tenant %q: %v", name, err)
+		}
+		cfg.Tenants = append(cfg.Tenants, config.Tenant{Name: name, ConfigDir: dir})
+	}
+	return home, cfg
+}
+
+func azurePath(t *testing.T, home string) string {
+	t.Helper()
+	return filepath.Join(home, ".azure")
+}
+
+func TestResolveDefaultNone(t *testing.T) {
+	_, cfg := azureSandbox(t)
+	info, err := config.ResolveDefault(cfg)
+	if err != nil {
+		t.Fatalf("ResolveDefault: %v", err)
+	}
+	if info.State != config.DefaultNone {
+		t.Errorf("State = %v, quería DefaultNone", info.State)
+	}
+	if info.Tenant != "" {
+		t.Errorf("Tenant = %q, quería vacío", info.Tenant)
+	}
+}
+
+func TestResolveDefaultNative(t *testing.T) {
+	home, cfg := azureSandbox(t)
+	// ~/.azure es un directorio real: el perfil nativo de az.
+	if err := os.MkdirAll(azurePath(t, home), 0755); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	info, err := config.ResolveDefault(cfg)
+	if err != nil {
+		t.Fatalf("ResolveDefault: %v", err)
+	}
+	if info.State != config.DefaultNative {
+		t.Errorf("State = %v, quería DefaultNative", info.State)
+	}
+}
+
+func TestResolveDefaultSet(t *testing.T) {
+	home, cfg := azureSandbox(t, "contoso")
+	target := cfg.FindTenant("contoso").ConfigDir
+	if err := os.Symlink(target, azurePath(t, home)); err != nil {
+		t.Fatalf("preparando enlace: %v", err)
+	}
+	info, err := config.ResolveDefault(cfg)
+	if err != nil {
+		t.Fatalf("ResolveDefault: %v", err)
+	}
+	if info.State != config.DefaultSet {
+		t.Fatalf("State = %v, quería DefaultSet", info.State)
+	}
+	if info.Tenant != "contoso" {
+		t.Errorf("Tenant = %q, quería «contoso»", info.Tenant)
+	}
+	if info.Target != target {
+		t.Errorf("Target = %q, quería %q", info.Target, target)
+	}
+}
+
+// Enlace a un directorio dentro de ~/.azsel/tenants pero de un tenant que no
+// está en config.json: no es un default de azsel.
+func TestResolveDefaultUnknownTenant(t *testing.T) {
+	home, cfg := azureSandbox(t, "contoso")
+	// Creamos el directorio de 'fabrikam' pero NO lo añadimos al config.
+	ghost, _, err := config.EnsureTenantDir("fabrikam")
+	if err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	if err := os.Symlink(ghost, azurePath(t, home)); err != nil {
+		t.Fatalf("preparando enlace: %v", err)
+	}
+	info, err := config.ResolveDefault(cfg)
+	if err != nil {
+		t.Fatalf("ResolveDefault: %v", err)
+	}
+	if info.State != config.DefaultForeign {
+		t.Errorf("State = %v, quería DefaultForeign (tenant desconocido)", info.State)
+	}
+}
+
+// Enlace a algo completamente fuera de ~/.azsel.
+func TestResolveDefaultForeign(t *testing.T) {
+	home, cfg := azureSandbox(t)
+	outside := t.TempDir()
+	if err := os.Symlink(outside, azurePath(t, home)); err != nil {
+		t.Fatalf("preparando enlace: %v", err)
+	}
+	info, err := config.ResolveDefault(cfg)
+	if err != nil {
+		t.Fatalf("ResolveDefault: %v", err)
+	}
+	if info.State != config.DefaultForeign {
+		t.Errorf("State = %v, quería DefaultForeign", info.State)
+	}
+	if info.Target != outside {
+		t.Errorf("Target = %q, quería %q", info.Target, outside)
+	}
+}
+
+// El caso peligroso: enlace cuyo destino ya no existe. az revienta con esto,
+// así que hay que distinguirlo.
+func TestResolveDefaultBroken(t *testing.T) {
+	home, cfg := azureSandbox(t, "contoso")
+	target := cfg.FindTenant("contoso").ConfigDir
+	if err := os.Symlink(target, azurePath(t, home)); err != nil {
+		t.Fatalf("preparando enlace: %v", err)
+	}
+	// Borramos el destino: el enlace queda colgando.
+	if err := os.RemoveAll(target); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	info, err := config.ResolveDefault(cfg)
+	if err != nil {
+		t.Fatalf("ResolveDefault: %v", err)
+	}
+	if info.State != config.DefaultBroken {
+		t.Errorf("State = %v, quería DefaultBroken", info.State)
+	}
+	if info.Target != target {
+		t.Errorf("Target = %q, quería %q para poder diagnosticar", info.Target, target)
+	}
+}
+
+// Un enlace escrito con ruta relativa debe resolverse igual que uno absoluto.
+func TestResolveDefaultRelativeSymlink(t *testing.T) {
+	home, cfg := azureSandbox(t, "contoso")
+	target := cfg.FindTenant("contoso").ConfigDir
+	rel, err := filepath.Rel(home, target)
+	if err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	// Enlace relativo desde ~/ hacia .azsel/tenants/contoso
+	if err := os.Symlink(rel, azurePath(t, home)); err != nil {
+		t.Fatalf("preparando enlace relativo: %v", err)
+	}
+	info, err := config.ResolveDefault(cfg)
+	if err != nil {
+		t.Fatalf("ResolveDefault: %v", err)
+	}
+	if info.State != config.DefaultSet || info.Tenant != "contoso" {
+		t.Errorf("State=%v Tenant=%q, quería DefaultSet/contoso", info.State, info.Tenant)
+	}
+}
+
+// Un enlace que apunta MÁS ADENTRO de un tenant (no al directorio del tenant)
+// no debe contar como default de azsel.
+func TestResolveDefaultLinkDeeperThanTenant(t *testing.T) {
+	home, cfg := azureSandbox(t, "contoso")
+	sub := filepath.Join(cfg.FindTenant("contoso").ConfigDir, "cliextensions")
+	if err := os.MkdirAll(sub, 0755); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	if err := os.Symlink(sub, azurePath(t, home)); err != nil {
+		t.Fatalf("preparando enlace: %v", err)
+	}
+	info, err := config.ResolveDefault(cfg)
+	if err != nil {
+		t.Fatalf("ResolveDefault: %v", err)
+	}
+	if info.State != config.DefaultForeign {
+		t.Errorf("State = %v, quería DefaultForeign (apunta dentro del tenant, no al tenant)", info.State)
+	}
+}
+
+// AzureDir necesita HOME para poder situar ~/.azure.
+func TestAzureDirNeedsHome(t *testing.T) {
+	t.Setenv("HOME", "")
+	if _, err := config.AzureDir(); err == nil {
+		t.Fatal("AzureDir devolvió nil sin HOME")
+	}
+}
+
+// Un fallo al resolver el destino del enlace que NO sea «no existe» —aquí un
+// componente de la ruta que es un fichero, no un directorio— debe propagarse
+// como error, no confundirse con un enlace roto.
+func TestResolveDefaultTargetStatError(t *testing.T) {
+	home, cfg := azureSandbox(t)
+	// Un fichero donde debería haber un directorio, y el enlace apunta a algo
+	// por debajo de él: Stat falla con ENOTDIR, que no es IsNotExist.
+	blocker := filepath.Join(t.TempDir(), "fichero")
+	if err := os.WriteFile(blocker, nil, 0644); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(blocker, "dentro"), azurePath(t, home)); err != nil {
+		t.Fatalf("preparando enlace: %v", err)
+	}
+	_, err := config.ResolveDefault(cfg)
+	if err == nil {
+		t.Fatal("ResolveDefault no propagó el error de Stat del destino")
+	}
+}

--- a/internal/config/setdefault_test.go
+++ b/internal/config/setdefault_test.go
@@ -342,3 +342,43 @@ func TestClearReportsNewestOfSeveralBackups(t *testing.T) {
 		t.Errorf("LatestBackup = %q, quería el más reciente", filepath.Base(res.LatestBackup))
 	}
 }
+
+// Bug del review: si EnsureSharedExtensionsLink falla, ~/.azure no debe haber
+// sido ya movido a backup. El enlace de extensiones va antes de tocar
+// ~/.azure, así que un fallo suyo deja ~/.azure intacto.
+func TestSetDefaultDoesNotBackUpIfExtensionsLinkFails(t *testing.T) {
+	home, cfg := azureSandbox(t, "contoso")
+	azure := filepath.Join(home, ".azure")
+	if err := os.MkdirAll(azure, 0755); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(azure, "tok"), []byte("sesión"), 0600); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	// Forzamos el fallo de EnsureSharedExtensionsLink: un fichero donde debería
+	// ir el directorio compartido de extensiones hace fallar su creación.
+	extPath := filepath.Join(home, ".azsel", "extensions")
+	_ = os.RemoveAll(extPath)
+	if err := os.WriteFile(extPath, nil, 0644); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+
+	if _, err := config.SetDefault(cfg, "contoso", "20260220-120000"); err == nil {
+		t.Fatal("SetDefault no falló pese al error de extensiones")
+	}
+	// ~/.azure sigue siendo el directorio real, no un enlace ni desaparecido.
+	fi, err := os.Lstat(azure)
+	if err != nil {
+		t.Fatalf("~/.azure desapareció pese al fallo: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		t.Error("~/.azure se convirtió en enlace pese al fallo de extensiones")
+	}
+	if _, err := os.Stat(filepath.Join(azure, "tok")); err != nil {
+		t.Error("el contenido de ~/.azure no sobrevivió: la sesión se movió sin enlace nuevo")
+	}
+	// Y no debe haber quedado un backup.
+	if entries, _ := os.ReadDir(filepath.Join(home, ".azsel", "backups")); len(entries) > 0 {
+		t.Error("se creó un backup pese a que la operación falló")
+	}
+}

--- a/internal/config/setdefault_test.go
+++ b/internal/config/setdefault_test.go
@@ -1,0 +1,268 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aolmosj/azsel/internal/config"
+)
+
+const ts = "20260220-120000"
+
+// assertLinkTo checks ~/.azure is a symlink pointing at want.
+func assertLinkTo(t *testing.T, home, want string) {
+	t.Helper()
+	azure := filepath.Join(home, ".azure")
+	fi, err := os.Lstat(azure)
+	if err != nil {
+		t.Fatalf("~/.azure no existe: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("~/.azure no es un enlace")
+	}
+	got, _ := os.Readlink(azure)
+	if got != want {
+		t.Errorf("~/.azure -> %q, quería %q", got, want)
+	}
+}
+
+func TestSetDefaultFromNothing(t *testing.T) {
+	home, cfg := azureSandbox(t, "contoso")
+	res, err := config.SetDefault(cfg, "contoso", ts)
+	if err != nil {
+		t.Fatalf("SetDefault: %v", err)
+	}
+	if res.BackupPath != "" {
+		t.Errorf("BackupPath = %q, no debía respaldar nada", res.BackupPath)
+	}
+	if res.Repointed {
+		t.Error("Repointed = true en creación fresca")
+	}
+	assertLinkTo(t, home, cfg.FindTenant("contoso").ConfigDir)
+}
+
+// El caso que motiva #29: ~/.azure es un directorio real con contenido.
+func TestSetDefaultBacksUpRealDirectory(t *testing.T) {
+	home, cfg := azureSandbox(t, "contoso")
+	azure := filepath.Join(home, ".azure")
+	if err := os.MkdirAll(azure, 0755); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	marker := filepath.Join(azure, "msal_token_cache.json")
+	if err := os.WriteFile(marker, []byte("sesión valiosa"), 0600); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+
+	res, err := config.SetDefault(cfg, "contoso", ts)
+	if err != nil {
+		t.Fatalf("SetDefault: %v", err)
+	}
+	if res.BackupPath == "" {
+		t.Fatal("no se reportó backup pese a haber un ~/.azure real")
+	}
+	// La sesión se conserva en el backup, no se destruye.
+	data, err := os.ReadFile(filepath.Join(res.BackupPath, "msal_token_cache.json"))
+	if err != nil {
+		t.Fatalf("el contenido no sobrevivió al backup: %v", err)
+	}
+	if string(data) != "sesión valiosa" {
+		t.Errorf("contenido del backup = %q", data)
+	}
+	assertLinkTo(t, home, cfg.FindTenant("contoso").ConfigDir)
+}
+
+func TestSetDefaultRepointsOwnLink(t *testing.T) {
+	home, cfg := azureSandbox(t, "contoso", "fabrikam")
+	if _, err := config.SetDefault(cfg, "contoso", ts); err != nil {
+		t.Fatalf("primer SetDefault: %v", err)
+	}
+	res, err := config.SetDefault(cfg, "fabrikam", ts)
+	if err != nil {
+		t.Fatalf("segundo SetDefault: %v", err)
+	}
+	if !res.Repointed {
+		t.Error("Repointed = false al mover un enlace existente")
+	}
+	if res.BackupPath != "" {
+		t.Error("se respaldó al repuntar un enlace propio; no debía")
+	}
+	assertLinkTo(t, home, cfg.FindTenant("fabrikam").ConfigDir)
+}
+
+// Un enlace ajeno no se toca.
+func TestSetDefaultRefusesForeignLink(t *testing.T) {
+	home, cfg := azureSandbox(t, "contoso")
+	outside := t.TempDir()
+	azure := filepath.Join(home, ".azure")
+	if err := os.Symlink(outside, azure); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	_, err := config.SetDefault(cfg, "contoso", ts)
+	if err == nil {
+		t.Fatal("SetDefault pisó un enlace ajeno")
+	}
+	// El enlace ajeno sigue intacto.
+	got, _ := os.Readlink(azure)
+	if got != outside {
+		t.Errorf("el enlace ajeno cambió a %q", got)
+	}
+}
+
+func TestSetDefaultRejectsUnknownTenant(t *testing.T) {
+	_, cfg := azureSandbox(t, "contoso")
+	if _, err := config.SetDefault(cfg, "fantasma", ts); err == nil {
+		t.Fatal("SetDefault aceptó un tenant inexistente")
+	}
+}
+
+// Reemplaza un enlace roto que era nuestro (apuntaba a un tenant borrado).
+func TestSetDefaultReplacesOwnBrokenLink(t *testing.T) {
+	home, cfg := azureSandbox(t, "contoso", "fabrikam")
+	azure := filepath.Join(home, ".azure")
+	// Enlace a un tenant que luego borramos: queda colgando pero es nuestro.
+	gone := cfg.FindTenant("fabrikam").ConfigDir
+	if err := os.Symlink(gone, azure); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	if err := os.RemoveAll(gone); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	if _, err := config.SetDefault(cfg, "contoso", ts); err != nil {
+		t.Fatalf("SetDefault sobre enlace roto propio: %v", err)
+	}
+	assertLinkTo(t, home, cfg.FindTenant("contoso").ConfigDir)
+}
+
+func TestSetDefaultCreatesSharedExtensionsLink(t *testing.T) {
+	_, cfg := azureSandbox(t, "contoso")
+	if _, err := config.SetDefault(cfg, "contoso", ts); err != nil {
+		t.Fatalf("SetDefault: %v", err)
+	}
+	shared, _ := config.ExtensionsDir()
+	link := filepath.Join(cfg.FindTenant("contoso").ConfigDir, "cliextensions")
+	got, err := os.Readlink(link)
+	if err != nil {
+		t.Fatalf("cliextensions no es enlace: %v", err)
+	}
+	if got != shared {
+		t.Errorf("cliextensions -> %q, quería el compartido %q", got, shared)
+	}
+}
+
+// Un cliextensions real preexistente (restos) se aparta, no se borra.
+func TestSetDefaultMovesAsideStaleExtensions(t *testing.T) {
+	_, cfg := azureSandbox(t, "contoso")
+	stale := filepath.Join(cfg.FindTenant("contoso").ConfigDir, "cliextensions")
+	if err := os.MkdirAll(stale, 0755); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stale, "vieja.txt"), []byte("x"), 0644); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	if _, err := config.SetDefault(cfg, "contoso", ts); err != nil {
+		t.Fatalf("SetDefault: %v", err)
+	}
+	if _, err := os.Stat(stale + ".bak"); err != nil {
+		t.Errorf("los restos no se apartaron a .bak: %v", err)
+	}
+}
+
+func TestClearDefault(t *testing.T) {
+	home, cfg := azureSandbox(t, "contoso")
+	if _, err := config.SetDefault(cfg, "contoso", ts); err != nil {
+		t.Fatalf("SetDefault: %v", err)
+	}
+	res, err := config.ClearDefault(cfg)
+	if err != nil {
+		t.Fatalf("ClearDefault: %v", err)
+	}
+	if !res.Cleared {
+		t.Error("Cleared = false pese a haber un default")
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".azure")); !os.IsNotExist(err) {
+		t.Errorf("~/.azure sigue existiendo tras clear (err=%v)", err)
+	}
+}
+
+func TestClearDefaultReportsLatestBackup(t *testing.T) {
+	home, cfg := azureSandbox(t, "contoso")
+	azure := filepath.Join(home, ".azure")
+	if err := os.MkdirAll(azure, 0755); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	if _, err := config.SetDefault(cfg, "contoso", ts); err != nil {
+		t.Fatalf("SetDefault: %v", err)
+	}
+	res, err := config.ClearDefault(cfg)
+	if err != nil {
+		t.Fatalf("ClearDefault: %v", err)
+	}
+	if res.LatestBackup == "" {
+		t.Error("clear no reportó el backup existente")
+	}
+}
+
+func TestClearDefaultNoDefault(t *testing.T) {
+	_, cfg := azureSandbox(t)
+	res, err := config.ClearDefault(cfg)
+	if err != nil {
+		t.Fatalf("ClearDefault sin default: %v", err)
+	}
+	if res.Cleared {
+		t.Error("Cleared = true sin default")
+	}
+}
+
+// clear no debe tocar el ~/.azure nativo de az.
+func TestClearDefaultLeavesNativeDirectory(t *testing.T) {
+	home, cfg := azureSandbox(t)
+	azure := filepath.Join(home, ".azure")
+	if err := os.MkdirAll(azure, 0755); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	if _, err := config.ClearDefault(cfg); err != nil {
+		t.Fatalf("ClearDefault: %v", err)
+	}
+	if _, err := os.Stat(azure); err != nil {
+		t.Errorf("clear borró el ~/.azure nativo: %v", err)
+	}
+}
+
+// La renombrada del enlace es atómica: nunca hay un instante sin ~/.azure.
+// Aquí lo que se comprueba es que un enlace previo se reemplaza sin pasar por
+// un estado inexistente observable — al menos que el resultado sea correcto.
+func TestReplaceIsAtomicResult(t *testing.T) {
+	home, cfg := azureSandbox(t, "a", "b")
+	if _, err := config.SetDefault(cfg, "a", ts); err != nil {
+		t.Fatalf("set a: %v", err)
+	}
+	if _, err := config.SetDefault(cfg, "b", ts); err != nil {
+		t.Fatalf("set b: %v", err)
+	}
+	// No debe quedar ningún fichero temporal.
+	azure := filepath.Join(home, ".azure")
+	if _, err := os.Lstat(azure + ".azsel-tmp." + itoa(os.Getpid())); !os.IsNotExist(err) {
+		t.Error("quedó un enlace temporal")
+	}
+	assertLinkTo(t, home, cfg.FindTenant("b").ConfigDir)
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	if neg {
+		b = append([]byte{'-'}, b...)
+	}
+	return string(b)
+}

--- a/internal/config/setdefault_test.go
+++ b/internal/config/setdefault_test.go
@@ -266,3 +266,79 @@ func itoa(n int) string {
 	}
 	return string(b)
 }
+
+func TestClearDefaultRefusesForeign(t *testing.T) {
+	home, cfg := azureSandbox(t)
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(home, ".azure")); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	if _, err := config.ClearDefault(cfg); err == nil {
+		t.Fatal("ClearDefault tocó un enlace ajeno")
+	}
+}
+
+func TestClearDefaultRemovesOwnBrokenLink(t *testing.T) {
+	home, cfg := azureSandbox(t, "contoso")
+	gone := cfg.FindTenant("contoso").ConfigDir
+	if err := os.Symlink(gone, filepath.Join(home, ".azure")); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	if err := os.RemoveAll(gone); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	res, err := config.ClearDefault(cfg)
+	if err != nil {
+		t.Fatalf("ClearDefault sobre enlace roto propio: %v", err)
+	}
+	if !res.Cleared {
+		t.Error("no se limpió un enlace roto que era nuestro")
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".azure")); !os.IsNotExist(err) {
+		t.Error("el enlace roto sigue ahí")
+	}
+}
+
+// clear NO debe limpiar un enlace roto ajeno.
+func TestClearDefaultLeavesForeignBrokenLink(t *testing.T) {
+	home, cfg := azureSandbox(t)
+	outside := filepath.Join(t.TempDir(), "no-existe")
+	if err := os.Symlink(outside, filepath.Join(home, ".azure")); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	res, err := config.ClearDefault(cfg)
+	if err != nil {
+		t.Fatalf("ClearDefault: %v", err)
+	}
+	if res.Cleared {
+		t.Error("se limpió un enlace roto ajeno")
+	}
+}
+
+// El backup reportado es el más reciente cuando hay varios.
+func TestClearReportsNewestOfSeveralBackups(t *testing.T) {
+	home, cfg := azureSandbox(t, "contoso")
+	backups := filepath.Join(home, ".azsel", "backups")
+	if err := os.MkdirAll(backups, 0700); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	for _, name := range []string{"azure-20260101-000000", "azure-20260115-000000"} {
+		if err := os.MkdirAll(filepath.Join(backups, name), 0700); err != nil {
+			t.Fatalf("preparando: %v", err)
+		}
+	}
+	// ~/.azure real, para que SetDefault genere un backup con marca posterior.
+	if err := os.MkdirAll(filepath.Join(home, ".azure"), 0755); err != nil {
+		t.Fatalf("preparando: %v", err)
+	}
+	if _, err := config.SetDefault(cfg, "contoso", "20260220-120001"); err != nil {
+		t.Fatalf("SetDefault: %v", err)
+	}
+	res, err := config.ClearDefault(cfg)
+	if err != nil {
+		t.Fatalf("ClearDefault: %v", err)
+	}
+	if filepath.Base(res.LatestBackup) != "azure-20260220-120001" {
+		t.Errorf("LatestBackup = %q, quería el más reciente", filepath.Base(res.LatestBackup))
+	}
+}

--- a/internal/tui/delegate.go
+++ b/internal/tui/delegate.go
@@ -66,6 +66,7 @@ func (d tenantDelegate) Render(w io.Writer, m list.Model, index int, listItem li
 func (d tenantDelegate) ShortHelp() []key.Binding {
 	return []key.Binding{
 		key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "activate")),
+		key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "set default")),
 	}
 }
 

--- a/internal/tui/item.go
+++ b/internal/tui/item.go
@@ -3,21 +3,30 @@ package tui
 import "github.com/aolmosj/azsel/internal/config"
 
 type TenantItem struct {
-	tenant config.Tenant
-	active bool
+	tenant    config.Tenant
+	active    bool
+	isDefault bool
 }
 
-func NewTenantItem(t config.Tenant, active bool) TenantItem {
-	return TenantItem{tenant: t, active: active}
+func NewTenantItem(t config.Tenant, active, isDefault bool) TenantItem {
+	return TenantItem{tenant: t, active: active, isDefault: isDefault}
 }
 
-// marker is the two-column prefix flagging the tenant AZURE_CONFIG_DIR
-// currently points at. Two columns either way, so names stay aligned.
+// marker is the two-column prefix flagging tenant state: column one is "*"
+// for the active tenant, column two is "D" for the default. They are
+// different things — active is where this shell points now, default is where
+// new shells start — so a tenant can carry either, both, or neither. Always
+// two columns wide so names stay aligned.
 func (t TenantItem) marker() string {
+	active := " "
 	if t.active {
-		return activeStyle.Render("* ")
+		active = activeStyle.Render("*")
 	}
-	return "  "
+	def := " "
+	if t.isDefault {
+		def = defaultStyle.Render("D")
+	}
+	return active + def
 }
 
 // FilterValue is the only method list.Item requires. Title and Description

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -13,9 +13,21 @@ type Model struct {
 	list     list.Model
 	selected *config.Tenant
 	quitting bool
+
+	// setDefault persists a tenant as the default. Injected so the model
+	// stays free of config and clock: cmd/tui.go closes over both. Nil
+	// disables the "d" key.
+	setDefault func(name string) error
+
+	// Confirmation state for the "d" key. Setting a default rewrites
+	// ~/.azure, which is more consequential than anything else the TUI does,
+	// so it asks first.
+	confirming  bool
+	confirmName string
+	status      string
 }
 
-func NewModel(tenants []config.Tenant, currentConfigDir, defaultName string) Model {
+func NewModel(tenants []config.Tenant, currentConfigDir, defaultName string, setDefault func(name string) error) Model {
 	items := make([]list.Item, len(tenants))
 	for i, t := range tenants {
 		active := t.ConfigDir == currentConfigDir
@@ -33,7 +45,22 @@ func NewModel(tenants []config.Tenant, currentConfigDir, defaultName string) Mod
 	l.Styles.FilterPrompt = lipgloss.NewStyle().Foreground(azureBlue)
 	l.Styles.FilterCursor = lipgloss.NewStyle().Foreground(azureBlue)
 
-	return Model{list: l}
+	return Model{list: l, setDefault: setDefault}
+}
+
+// applyDefault marks name as the default across the list items, leaving one
+// place that decides the marker (kept from #6).
+func (m *Model) applyDefault(name string) {
+	items := m.list.Items()
+	for i, it := range items {
+		ti, ok := it.(TenantItem)
+		if !ok {
+			continue
+		}
+		ti.isDefault = strings.EqualFold(ti.tenant.Name, name)
+		items[i] = ti
+	}
+	m.list.SetItems(items)
 }
 
 func (m Model) Init() tea.Cmd {
@@ -48,6 +75,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
+		// While confirming, keys answer the prompt and never reach the list.
+		if m.confirming {
+			switch msg.String() {
+			case "y", "Y":
+				m.confirming = false
+				if err := m.setDefault(m.confirmName); err != nil {
+					m.status = "Could not set default: " + err.Error()
+				} else {
+					m.applyDefault(m.confirmName)
+					m.status = "Default is now " + m.confirmName + "."
+				}
+			default:
+				m.confirming = false
+				m.status = ""
+			}
+			return m, nil
+		}
+
 		if m.list.FilterState() == list.Filtering {
 			break
 		}
@@ -55,6 +100,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "q", "ctrl+c":
 			m.quitting = true
 			return m, tea.Quit
+		case "d":
+			// Only with a way to persist it, and only on a real item.
+			if m.setDefault != nil {
+				if item, ok := m.list.SelectedItem().(TenantItem); ok {
+					m.confirming = true
+					m.confirmName = item.tenant.Name
+					m.status = ""
+					return m, nil
+				}
+			}
 		}
 
 	case selectTenantMsg:
@@ -73,7 +128,14 @@ func (m Model) View() string {
 	if m.quitting {
 		return ""
 	}
-	return appStyle.Render(m.list.View())
+	body := m.list.View()
+	switch {
+	case m.confirming:
+		body += "\n\n" + confirmStyle.Render("Set "+m.confirmName+" as the default? This repoints ~/.azure. [y/N]")
+	case m.status != "":
+		body += "\n\n" + statusMsgStyle.Render(m.status)
+	}
+	return appStyle.Render(body)
 }
 
 func (m Model) Selected() *config.Tenant {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"strings"
+
 	"github.com/aolmosj/azsel/internal/config"
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
@@ -13,11 +15,12 @@ type Model struct {
 	quitting bool
 }
 
-func NewModel(tenants []config.Tenant, currentConfigDir string) Model {
+func NewModel(tenants []config.Tenant, currentConfigDir, defaultName string) Model {
 	items := make([]list.Item, len(tenants))
 	for i, t := range tenants {
 		active := t.ConfigDir == currentConfigDir
-		items[i] = NewTenantItem(t, active)
+		isDefault := defaultName != "" && strings.EqualFold(t.Name, defaultName)
+		items[i] = NewTenantItem(t, active, isDefault)
 	}
 
 	delegate := newDelegate()

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -14,10 +14,11 @@ type Model struct {
 	selected *config.Tenant
 	quitting bool
 
-	// setDefault persists a tenant as the default. Injected so the model
-	// stays free of config and clock: cmd/tui.go closes over both. Nil
-	// disables the "d" key.
-	setDefault func(name string) error
+	// setDefault persists a tenant as the default and returns a note to show
+	// (e.g. where an existing ~/.azure was backed up), empty if none. Injected
+	// so the model stays free of config and clock: cmd/tui.go closes over
+	// both. Nil disables the "d" key.
+	setDefault func(name string) (note string, err error)
 
 	// Confirmation state for the "d" key. Setting a default rewrites
 	// ~/.azure, which is more consequential than anything else the TUI does,
@@ -27,7 +28,7 @@ type Model struct {
 	status      string
 }
 
-func NewModel(tenants []config.Tenant, currentConfigDir, defaultName string, setDefault func(name string) error) Model {
+func NewModel(tenants []config.Tenant, currentConfigDir, defaultName string, setDefault func(name string) (string, error)) Model {
 	items := make([]list.Item, len(tenants))
 	for i, t := range tenants {
 		active := t.ConfigDir == currentConfigDir
@@ -80,11 +81,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch msg.String() {
 			case "y", "Y":
 				m.confirming = false
-				if err := m.setDefault(m.confirmName); err != nil {
+				if note, err := m.setDefault(m.confirmName); err != nil {
 					m.status = "Could not set default: " + err.Error()
 				} else {
 					m.applyDefault(m.confirmName)
 					m.status = "Default is now " + m.confirmName + "."
+					if note != "" {
+						m.status += " " + note
+					}
 				}
 			default:
 				m.confirming = false

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -45,7 +45,7 @@ func send(t *testing.T, m Model, msgs ...tea.Msg) (Model, tea.Cmd) {
 // guarda en ningún sitio, lo que permite que cada terminal tenga el suyo.
 func TestNewModelMarksActiveTenant(t *testing.T) {
 	ts := tenants()
-	m := NewModel(ts, ts[1].ConfigDir)
+	m := NewModel(ts, ts[1].ConfigDir, "")
 
 	items := m.list.Items()
 	if len(items) != 2 {
@@ -61,7 +61,7 @@ func TestNewModelMarksActiveTenant(t *testing.T) {
 
 func TestNewModelNoActiveTenant(t *testing.T) {
 	for _, dir := range []string{"", "/otro/sitio"} {
-		m := NewModel(tenants(), dir)
+		m := NewModel(tenants(), dir, "")
 		for _, it := range m.list.Items() {
 			if it.(TenantItem).active {
 				t.Errorf("con AZURE_CONFIG_DIR=%q hay un tenant marcado activo", dir)
@@ -71,7 +71,7 @@ func TestNewModelNoActiveTenant(t *testing.T) {
 }
 
 func TestSelectedIsNilUntilChosen(t *testing.T) {
-	m := NewModel(tenants(), "")
+	m := NewModel(tenants(), "", "")
 	if got := m.Selected(); got != nil {
 		t.Errorf("Selected() = %+v antes de elegir, quería nil", got)
 	}
@@ -79,8 +79,8 @@ func TestSelectedIsNilUntilChosen(t *testing.T) {
 
 func TestSelectTenantMsgSetsSelection(t *testing.T) {
 	ts := tenants()
-	m := NewModel(ts, "")
-	m, _ = send(t, m, selectTenantMsg{tenant: NewTenantItem(ts[1], false)})
+	m := NewModel(ts, "", "")
+	m, _ = send(t, m, selectTenantMsg{tenant: NewTenantItem(ts[1], false, false)})
 
 	got := m.Selected()
 	if got == nil {
@@ -98,7 +98,7 @@ func TestSelectTenantMsgSetsSelection(t *testing.T) {
 // Pulsar enter sobre un item debe emitir selectTenantMsg. Es el delegate quien
 // lo produce, no el modelo.
 func TestEnterEmitsSelectTenantMsg(t *testing.T) {
-	m := NewModel(tenants(), "")
+	m := NewModel(tenants(), "", "")
 	_, cmd := send(t, m, keyMsg("enter"))
 	if cmd == nil {
 		t.Fatal("enter no emitió ningún comando")
@@ -110,7 +110,7 @@ func TestEnterEmitsSelectTenantMsg(t *testing.T) {
 
 func TestQuitKeys(t *testing.T) {
 	for _, k := range []tea.KeyMsg{keyMsg("q"), {Type: tea.KeyCtrlC}} {
-		m := NewModel(tenants(), "")
+		m := NewModel(tenants(), "", "")
 		m, _ = send(t, m, k)
 		if v := m.View(); v != "" {
 			t.Errorf("tras %v, View() = %q, quería vacío", k, v)
@@ -124,7 +124,7 @@ func TestQuitKeys(t *testing.T) {
 // Protege la guarda de Update: mientras se filtra, «q» es texto de búsqueda,
 // no la orden de salir. Sin ella, buscar «quux» cerraría la aplicación.
 func TestQuitKeyIsTextWhileFiltering(t *testing.T) {
-	m := NewModel(tenants(), "")
+	m := NewModel(tenants(), "", "")
 	m, _ = send(t, m, keyMsg("/"))
 	if m.list.FilterState() != list.Filtering {
 		t.Fatalf("«/» no entró en modo filtro: estado = %v", m.list.FilterState())
@@ -141,7 +141,7 @@ func TestQuitKeyIsTextWhileFiltering(t *testing.T) {
 
 // El filtro busca por nombre y por ID: pegar un GUID debe encontrar su tenant.
 func TestFilterValueCoversNameAndID(t *testing.T) {
-	item := NewTenantItem(tenants()[0], false)
+	item := NewTenantItem(tenants()[0], false, false)
 	got := item.FilterValue()
 	if !strings.Contains(got, "acme") {
 		t.Errorf("FilterValue() = %q, quería que incluyera el nombre", got)
@@ -152,7 +152,7 @@ func TestFilterValueCoversNameAndID(t *testing.T) {
 }
 
 func TestWindowSizeMsgResizesList(t *testing.T) {
-	m := NewModel(tenants(), "")
+	m := NewModel(tenants(), "", "")
 	m, _ = send(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
 	if w := m.list.Width(); w >= 120 {
 		t.Errorf("ancho de la lista = %d, quería descontar el margen de 120", w)
@@ -165,7 +165,7 @@ func TestWindowSizeMsgResizesList(t *testing.T) {
 // El delegate pinta dos líneas por tenant, nombre e ID, y marca el activo.
 func TestDelegateRender(t *testing.T) {
 	ts := tenants()
-	m := NewModel(ts, ts[0].ConfigDir)
+	m := NewModel(ts, ts[0].ConfigDir, "")
 	d := newDelegate()
 
 	if got := d.Height(); got != 2 {
@@ -198,11 +198,11 @@ func TestDelegateRender(t *testing.T) {
 func TestMarker(t *testing.T) {
 	ts := tenants()
 
-	active := NewTenantItem(ts[0], true).marker()
+	active := NewTenantItem(ts[0], true, false).marker()
 	if !strings.Contains(active, "*") {
 		t.Errorf("marcador activo = %q, quería que incluyera «*»", active)
 	}
-	inactive := NewTenantItem(ts[0], false).marker()
+	inactive := NewTenantItem(ts[0], false, false).marker()
 	if strings.Contains(inactive, "*") {
 		t.Errorf("marcador inactivo = %q, no quería «*»", inactive)
 	}
@@ -221,7 +221,7 @@ func TestMarker(t *testing.T) {
 // tal cual.
 func TestDelegateRenderShowsSameDataSelectedOrNot(t *testing.T) {
 	ts := tenants()
-	m := NewModel(ts, "")
+	m := NewModel(ts, "", "")
 	d := newDelegate()
 
 	var selected, normal bytes.Buffer
@@ -260,7 +260,7 @@ func helpKeys(m Model) []string {
 // de cursor y su propio KeyMap, que ya aporta Filter y Quit. Declararlas
 // también en el delegate las imprimía dos veces.
 func TestHelpHasNoDuplicateKeys(t *testing.T) {
-	m := NewModel(tenants(), "")
+	m := NewModel(tenants(), "", "")
 
 	seen := map[string]int{}
 	for _, k := range helpKeys(m) {
@@ -276,7 +276,7 @@ func TestHelpHasNoDuplicateKeys(t *testing.T) {
 // El delegate solo debe aportar lo que el list no sabe. enter lo maneja él;
 // «/» y «q» las pone el list por su cuenta.
 func TestHelpContentsAreComplete(t *testing.T) {
-	m := NewModel(tenants(), "")
+	m := NewModel(tenants(), "", "")
 	keys := helpKeys(m)
 
 	has := func(want string) bool {
@@ -301,7 +301,7 @@ func TestHelpContentsAreComplete(t *testing.T) {
 // Con el filtro abierto la barra cambia de forma: el list omite el ShortHelp
 // del delegate. Tampoco ahí debe haber repeticiones.
 func TestHelpHasNoDuplicateKeysWhileFiltering(t *testing.T) {
-	m := NewModel(tenants(), "")
+	m := NewModel(tenants(), "", "")
 	m, _ = send(t, m, keyMsg("/"))
 	if m.list.FilterState() != list.Filtering {
 		t.Fatalf("no se entró en modo filtro: %v", m.list.FilterState())
@@ -320,7 +320,7 @@ func TestHelpHasNoDuplicateKeysWhileFiltering(t *testing.T) {
 
 // Y la comprobación de extremo a extremo, sobre lo que el usuario ve.
 func TestRenderedHelpHasNoRepeatedEntries(t *testing.T) {
-	m := NewModel(tenants(), "")
+	m := NewModel(tenants(), "", "")
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 14})
 	view := ansi.Strip(updated.(Model).View())
 
@@ -328,5 +328,76 @@ func TestRenderedHelpHasNoRepeatedEntries(t *testing.T) {
 		if got := strings.Count(view, entry); got != 1 {
 			t.Errorf("%q aparece %d veces en la vista, quería 1:\n%s", entry, got, view)
 		}
+	}
+}
+
+// El marcador distingue las cuatro combinaciones de activo y default, y
+// mantiene dos columnas en todas para que los nombres queden alineados.
+func TestMarkerDefaultAndActive(t *testing.T) {
+	ts := tenants()
+	cases := []struct {
+		name            string
+		active, isDef   bool
+		wantStar, wantD bool
+	}{
+		{"ninguno", false, false, false, false},
+		{"solo activo", true, false, true, false},
+		{"solo default", false, true, false, true},
+		{"ambos", true, true, true, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := ansi.Strip(NewTenantItem(ts[0], c.active, c.isDef).marker())
+			if strings.Contains(m, "*") != c.wantStar {
+				t.Errorf("marcador %q: presencia de «*» = %v, quería %v", m, strings.Contains(m, "*"), c.wantStar)
+			}
+			if strings.Contains(m, "D") != c.wantD {
+				t.Errorf("marcador %q: presencia de «D» = %v, quería %v", m, strings.Contains(m, "D"), c.wantD)
+			}
+			if len(m) != 2 {
+				t.Errorf("marcador %q mide %d columnas, quería 2", m, len(m))
+			}
+		})
+	}
+}
+
+// NewModel marca como default el tenant cuyo nombre coincide, sin distinguir
+// mayúsculas, y ninguno si el nombre está vacío.
+func TestNewModelMarksDefault(t *testing.T) {
+	ts := tenants() // acme, globex
+	m := NewModel(ts, "", "GLOBEX")
+	items := m.list.Items()
+	if items[0].(TenantItem).isDefault {
+		t.Error("acme marcado como default")
+	}
+	if !items[1].(TenantItem).isDefault {
+		t.Error("globex no marcado como default pese a coincidir (case-insensitive)")
+	}
+
+	none := NewModel(ts, "", "")
+	for _, it := range none.list.Items() {
+		if it.(TenantItem).isDefault {
+			t.Error("hay un default marcado con defaultName vacío")
+		}
+	}
+}
+
+// Activo y default son independientes: el render los muestra a la vez cuando
+// coinciden en el mismo tenant, y por separado cuando no.
+func TestDelegateRendersDefaultMarker(t *testing.T) {
+	ts := tenants()
+	// acme activo, globex default.
+	m := NewModel(ts, ts[0].ConfigDir, "globex")
+	d := newDelegate()
+
+	var acme, globex bytes.Buffer
+	d.Render(&acme, m.list, 0, m.list.Items()[0])
+	d.Render(&globex, m.list, 1, m.list.Items()[1])
+
+	if a := ansi.Strip(acme.String()); !strings.Contains(a, "*") || strings.Contains(a[:3], "D") {
+		t.Errorf("acme debería ser activo y no default: %q", a)
+	}
+	if g := ansi.Strip(globex.String()); !strings.Contains(g[:3], "D") {
+		t.Errorf("globex debería mostrar el marcador de default: %q", g)
 	}
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -45,7 +45,7 @@ func send(t *testing.T, m Model, msgs ...tea.Msg) (Model, tea.Cmd) {
 // guarda en ningún sitio, lo que permite que cada terminal tenga el suyo.
 func TestNewModelMarksActiveTenant(t *testing.T) {
 	ts := tenants()
-	m := NewModel(ts, ts[1].ConfigDir, "")
+	m := NewModel(ts, ts[1].ConfigDir, "", nil)
 
 	items := m.list.Items()
 	if len(items) != 2 {
@@ -61,7 +61,7 @@ func TestNewModelMarksActiveTenant(t *testing.T) {
 
 func TestNewModelNoActiveTenant(t *testing.T) {
 	for _, dir := range []string{"", "/otro/sitio"} {
-		m := NewModel(tenants(), dir, "")
+		m := NewModel(tenants(), dir, "", nil)
 		for _, it := range m.list.Items() {
 			if it.(TenantItem).active {
 				t.Errorf("con AZURE_CONFIG_DIR=%q hay un tenant marcado activo", dir)
@@ -71,7 +71,7 @@ func TestNewModelNoActiveTenant(t *testing.T) {
 }
 
 func TestSelectedIsNilUntilChosen(t *testing.T) {
-	m := NewModel(tenants(), "", "")
+	m := NewModel(tenants(), "", "", nil)
 	if got := m.Selected(); got != nil {
 		t.Errorf("Selected() = %+v antes de elegir, quería nil", got)
 	}
@@ -79,7 +79,7 @@ func TestSelectedIsNilUntilChosen(t *testing.T) {
 
 func TestSelectTenantMsgSetsSelection(t *testing.T) {
 	ts := tenants()
-	m := NewModel(ts, "", "")
+	m := NewModel(ts, "", "", nil)
 	m, _ = send(t, m, selectTenantMsg{tenant: NewTenantItem(ts[1], false, false)})
 
 	got := m.Selected()
@@ -98,7 +98,7 @@ func TestSelectTenantMsgSetsSelection(t *testing.T) {
 // Pulsar enter sobre un item debe emitir selectTenantMsg. Es el delegate quien
 // lo produce, no el modelo.
 func TestEnterEmitsSelectTenantMsg(t *testing.T) {
-	m := NewModel(tenants(), "", "")
+	m := NewModel(tenants(), "", "", nil)
 	_, cmd := send(t, m, keyMsg("enter"))
 	if cmd == nil {
 		t.Fatal("enter no emitió ningún comando")
@@ -110,7 +110,7 @@ func TestEnterEmitsSelectTenantMsg(t *testing.T) {
 
 func TestQuitKeys(t *testing.T) {
 	for _, k := range []tea.KeyMsg{keyMsg("q"), {Type: tea.KeyCtrlC}} {
-		m := NewModel(tenants(), "", "")
+		m := NewModel(tenants(), "", "", nil)
 		m, _ = send(t, m, k)
 		if v := m.View(); v != "" {
 			t.Errorf("tras %v, View() = %q, quería vacío", k, v)
@@ -124,7 +124,7 @@ func TestQuitKeys(t *testing.T) {
 // Protege la guarda de Update: mientras se filtra, «q» es texto de búsqueda,
 // no la orden de salir. Sin ella, buscar «quux» cerraría la aplicación.
 func TestQuitKeyIsTextWhileFiltering(t *testing.T) {
-	m := NewModel(tenants(), "", "")
+	m := NewModel(tenants(), "", "", nil)
 	m, _ = send(t, m, keyMsg("/"))
 	if m.list.FilterState() != list.Filtering {
 		t.Fatalf("«/» no entró en modo filtro: estado = %v", m.list.FilterState())
@@ -152,7 +152,7 @@ func TestFilterValueCoversNameAndID(t *testing.T) {
 }
 
 func TestWindowSizeMsgResizesList(t *testing.T) {
-	m := NewModel(tenants(), "", "")
+	m := NewModel(tenants(), "", "", nil)
 	m, _ = send(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
 	if w := m.list.Width(); w >= 120 {
 		t.Errorf("ancho de la lista = %d, quería descontar el margen de 120", w)
@@ -165,7 +165,7 @@ func TestWindowSizeMsgResizesList(t *testing.T) {
 // El delegate pinta dos líneas por tenant, nombre e ID, y marca el activo.
 func TestDelegateRender(t *testing.T) {
 	ts := tenants()
-	m := NewModel(ts, ts[0].ConfigDir, "")
+	m := NewModel(ts, ts[0].ConfigDir, "", nil)
 	d := newDelegate()
 
 	if got := d.Height(); got != 2 {
@@ -221,7 +221,7 @@ func TestMarker(t *testing.T) {
 // tal cual.
 func TestDelegateRenderShowsSameDataSelectedOrNot(t *testing.T) {
 	ts := tenants()
-	m := NewModel(ts, "", "")
+	m := NewModel(ts, "", "", nil)
 	d := newDelegate()
 
 	var selected, normal bytes.Buffer
@@ -260,7 +260,7 @@ func helpKeys(m Model) []string {
 // de cursor y su propio KeyMap, que ya aporta Filter y Quit. Declararlas
 // también en el delegate las imprimía dos veces.
 func TestHelpHasNoDuplicateKeys(t *testing.T) {
-	m := NewModel(tenants(), "", "")
+	m := NewModel(tenants(), "", "", nil)
 
 	seen := map[string]int{}
 	for _, k := range helpKeys(m) {
@@ -276,7 +276,7 @@ func TestHelpHasNoDuplicateKeys(t *testing.T) {
 // El delegate solo debe aportar lo que el list no sabe. enter lo maneja él;
 // «/» y «q» las pone el list por su cuenta.
 func TestHelpContentsAreComplete(t *testing.T) {
-	m := NewModel(tenants(), "", "")
+	m := NewModel(tenants(), "", "", nil)
 	keys := helpKeys(m)
 
 	has := func(want string) bool {
@@ -293,15 +293,24 @@ func TestHelpContentsAreComplete(t *testing.T) {
 		}
 	}
 
-	if got := newDelegate().ShortHelp(); len(got) != 1 {
-		t.Errorf("el delegate declara %d bindings, quería 1 (solo enter)", len(got))
+	// El delegate declara solo las teclas que el list no conoce: enter y d.
+	// «/» y «q» las aporta el list, y no deben repetirse (#21).
+	declared := map[string]bool{}
+	for _, b := range newDelegate().ShortHelp() {
+		declared[b.Help().Key] = true
+	}
+	if !declared["enter"] || !declared["d"] {
+		t.Errorf("el delegate debe declarar enter y d, tiene %v", declared)
+	}
+	if declared["/"] || declared["q"] {
+		t.Errorf("el delegate no debe declarar / ni q (los pone el list): %v", declared)
 	}
 }
 
 // Con el filtro abierto la barra cambia de forma: el list omite el ShortHelp
 // del delegate. Tampoco ahí debe haber repeticiones.
 func TestHelpHasNoDuplicateKeysWhileFiltering(t *testing.T) {
-	m := NewModel(tenants(), "", "")
+	m := NewModel(tenants(), "", "", nil)
 	m, _ = send(t, m, keyMsg("/"))
 	if m.list.FilterState() != list.Filtering {
 		t.Fatalf("no se entró en modo filtro: %v", m.list.FilterState())
@@ -320,7 +329,7 @@ func TestHelpHasNoDuplicateKeysWhileFiltering(t *testing.T) {
 
 // Y la comprobación de extremo a extremo, sobre lo que el usuario ve.
 func TestRenderedHelpHasNoRepeatedEntries(t *testing.T) {
-	m := NewModel(tenants(), "", "")
+	m := NewModel(tenants(), "", "", nil)
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 14})
 	view := ansi.Strip(updated.(Model).View())
 
@@ -365,7 +374,7 @@ func TestMarkerDefaultAndActive(t *testing.T) {
 // mayúsculas, y ninguno si el nombre está vacío.
 func TestNewModelMarksDefault(t *testing.T) {
 	ts := tenants() // acme, globex
-	m := NewModel(ts, "", "GLOBEX")
+	m := NewModel(ts, "", "GLOBEX", nil)
 	items := m.list.Items()
 	if items[0].(TenantItem).isDefault {
 		t.Error("acme marcado como default")
@@ -374,7 +383,7 @@ func TestNewModelMarksDefault(t *testing.T) {
 		t.Error("globex no marcado como default pese a coincidir (case-insensitive)")
 	}
 
-	none := NewModel(ts, "", "")
+	none := NewModel(ts, "", "", nil)
 	for _, it := range none.list.Items() {
 		if it.(TenantItem).isDefault {
 			t.Error("hay un default marcado con defaultName vacío")
@@ -387,7 +396,7 @@ func TestNewModelMarksDefault(t *testing.T) {
 func TestDelegateRendersDefaultMarker(t *testing.T) {
 	ts := tenants()
 	// acme activo, globex default.
-	m := NewModel(ts, ts[0].ConfigDir, "globex")
+	m := NewModel(ts, ts[0].ConfigDir, "globex", nil)
 	d := newDelegate()
 
 	var acme, globex bytes.Buffer
@@ -401,3 +410,94 @@ func TestDelegateRendersDefaultMarker(t *testing.T) {
 		t.Errorf("globex debería mostrar el marcador de default: %q", g)
 	}
 }
+
+// La tecla "d" pide confirmación antes de fijar el default, porque reescribe
+// ~/.azure — la única acción de la TUI con efecto en disco.
+func TestSetDefaultKeyAsksConfirmation(t *testing.T) {
+	ts := tenants()
+	var called []string
+	set := func(name string) error { called = append(called, name); return nil }
+	m := NewModel(ts, "", "", set)
+
+	// d sobre el primer item entra en confirmación, sin fijar aún.
+	m, _ = send(t, m, keyMsg("d"))
+	if !strings.Contains(m.View(), "as the default?") {
+		t.Errorf("d no mostró la confirmación:\n%s", ansi.Strip(m.View()))
+	}
+	if len(called) != 0 {
+		t.Errorf("se fijó el default antes de confirmar: %v", called)
+	}
+
+	// y confirma: se fija y el marcador se actualiza.
+	m, _ = send(t, m, keyMsg("y"))
+	if len(called) != 1 || called[0] != ts[0].Name {
+		t.Fatalf("setDefault llamado con %v, quería [%s]", called, ts[0].Name)
+	}
+	if !m.list.Items()[0].(TenantItem).isDefault {
+		t.Error("el marcador de default no se actualizó tras confirmar")
+	}
+}
+
+func TestSetDefaultKeyCancelled(t *testing.T) {
+	ts := tenants()
+	var called []string
+	set := func(name string) error { called = append(called, name); return nil }
+	m := NewModel(ts, "", "", set)
+
+	m, _ = send(t, m, keyMsg("d"))
+	m, _ = send(t, m, keyMsg("n"))
+	if len(called) != 0 {
+		t.Errorf("n no canceló: se fijó %v", called)
+	}
+	if strings.Contains(m.View(), "as the default?") {
+		t.Error("sigue mostrando la confirmación tras cancelar")
+	}
+}
+
+// Un error al fijar se muestra, no se traga.
+func TestSetDefaultKeyReportsError(t *testing.T) {
+	ts := tenants()
+	set := func(name string) error { return errTest }
+	m := NewModel(ts, "", "", set)
+	m, _ = send(t, m, keyMsg("d"))
+	m, _ = send(t, m, keyMsg("y"))
+	if !strings.Contains(m.View(), "Could not set default") {
+		t.Errorf("no se mostró el error:\n%s", ansi.Strip(m.View()))
+	}
+}
+
+// Sin callback (setDefault nil), la tecla d no hace nada.
+func TestSetDefaultKeyNoopWithoutCallback(t *testing.T) {
+	m := NewModel(tenants(), "", "", nil)
+	m, _ = send(t, m, keyMsg("d"))
+	if strings.Contains(m.View(), "as the default?") {
+		t.Error("d entró en confirmación sin callback")
+	}
+}
+
+// Durante el filtrado, "d" es texto de búsqueda, no la orden de fijar default
+// — la misma guarda que protege a "q" (#7).
+func TestSetDefaultKeyIsTextWhileFiltering(t *testing.T) {
+	ts := tenants()
+	var called []string
+	set := func(name string) error { called = append(called, name); return nil }
+	m := NewModel(ts, "", "", set)
+
+	m, _ = send(t, m, keyMsg("/"))
+	if m.list.FilterState() != list.Filtering {
+		t.Fatalf("no se entró en filtrado")
+	}
+	m, _ = send(t, m, keyMsg("d"))
+	if strings.Contains(m.View(), "as the default?") {
+		t.Error("d abrió la confirmación durante el filtrado")
+	}
+	if len(called) != 0 {
+		t.Errorf("d fijó el default durante el filtrado: %v", called)
+	}
+}
+
+var errTest = &testError{}
+
+type testError struct{}
+
+func (*testError) Error() string { return "boom" }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -416,7 +416,7 @@ func TestDelegateRendersDefaultMarker(t *testing.T) {
 func TestSetDefaultKeyAsksConfirmation(t *testing.T) {
 	ts := tenants()
 	var called []string
-	set := func(name string) error { called = append(called, name); return nil }
+	set := func(name string) (string, error) { called = append(called, name); return "", nil }
 	m := NewModel(ts, "", "", set)
 
 	// d sobre el primer item entra en confirmación, sin fijar aún.
@@ -441,7 +441,7 @@ func TestSetDefaultKeyAsksConfirmation(t *testing.T) {
 func TestSetDefaultKeyCancelled(t *testing.T) {
 	ts := tenants()
 	var called []string
-	set := func(name string) error { called = append(called, name); return nil }
+	set := func(name string) (string, error) { called = append(called, name); return "", nil }
 	m := NewModel(ts, "", "", set)
 
 	m, _ = send(t, m, keyMsg("d"))
@@ -457,7 +457,7 @@ func TestSetDefaultKeyCancelled(t *testing.T) {
 // Un error al fijar se muestra, no se traga.
 func TestSetDefaultKeyReportsError(t *testing.T) {
 	ts := tenants()
-	set := func(name string) error { return errTest }
+	set := func(name string) (string, error) { return "", errTest }
 	m := NewModel(ts, "", "", set)
 	m, _ = send(t, m, keyMsg("d"))
 	m, _ = send(t, m, keyMsg("y"))
@@ -480,7 +480,7 @@ func TestSetDefaultKeyNoopWithoutCallback(t *testing.T) {
 func TestSetDefaultKeyIsTextWhileFiltering(t *testing.T) {
 	ts := tenants()
 	var called []string
-	set := func(name string) error { called = append(called, name); return nil }
+	set := func(name string) (string, error) { called = append(called, name); return "", nil }
 	m := NewModel(ts, "", "", set)
 
 	m, _ = send(t, m, keyMsg("/"))

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -20,6 +20,11 @@ var (
 			Foreground(green).
 			Bold(true)
 
+	// The default tenant, distinct from the active one, in Azure blue.
+	defaultStyle = lipgloss.NewStyle().
+			Foreground(azureBlue).
+			Bold(true)
+
 	// Selected item in list
 	selectedTitleStyle = lipgloss.NewStyle().
 				Foreground(azureBlue).

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -53,5 +53,13 @@ var (
 			Background(azureBlue).
 			Padding(0, 1)
 
+	confirmStyle = lipgloss.NewStyle().
+			Foreground(white).
+			Background(azureBlue).
+			Padding(0, 1)
+
+	statusMsgStyle = lipgloss.NewStyle().
+			Foreground(azureLight)
+
 	appStyle = lipgloss.NewStyle().Margin(1, 2)
 )


### PR DESCRIPTION
Implements the complete **Phase 2** (epic #12): a default tenant that applies to every new shell — and to any process that runs `az`, including cron, launchd and IDEs — without running `azsel` by hand.

Closes #24, #25, #26, #27, #28, #29. The design was settled in #23.

## The mechanism: symlink

`~/.azure` becomes a link to the default tenant's profile. The epic proposed environment variables with a shell hook; during #23 the symlink was adopted, superior where it mattered most:

| | Variables + hook | Symlink |
|---|---|---|
| Scope | interactive shells only | **any process that runs `az`** |
| Startup cost | `test -f` + `source` per shell | **zero** |
| Precedence | has to be programmed | **imposed by `az`** |
| Shell function | has to be touched | **untouched** |

All verified by running `az`, not reasoned.

## What's included

| Issue | Delivers |
|---|---|
| #24 | `ResolveDefault` classifies `~/.azure` into five states; the link is the single source of truth (no field in `config.json`) |
| #26 | Atomic link management (create/repoint/clean up) + extensions shared via symlink, retiring `AZURE_EXTENSION_DIR` |
| #29 | An existing `~/.azure` is **moved** to `~/.azsel/backups/`, never destroyed |
| #25 | `azsel default` command — set / show / `--clear` |
| #27 | Integration tests against real `az`, opt-in (`AZSEL_INTEGRATION=1`) and with a dedicated CI job |
| #28 | `DEFAULT` column in `list`, marker in the TUI, `d` key with confirmation |

## Observable behavior changes

- **`AZURE_EXTENSION_DIR` is no longer set** in `use`, the TUI and `Login`. Extensions are shared via each tenant's `cliextensions` symlink. Existing tenants are migrated lazily on the next `azsel use` (their real `cliextensions` is moved aside to `.bak`, not deleted). The variable still wins if someone exports it.
- **Changing the default affects already-open shells** that haven't run `azsel use`, because `~/.azure` is resolved on every `az` invocation. Decided preferable in #23; documented.

## Recorded decisions

- **No `default` field in `config.json`**: the link already says so; duplicating it would reintroduce the desync the link eliminates.
- **Don't import `~/.azure`**: the real data showed it's multi-tenant (34 subscriptions, 3 tenants). Importing it as *one* tenant would be a lie.
- **Backup, not refusal**: a real `~/.azure` is always moved aside to a named backup with a notice, instead of demanding a flag.
- **Opt-in integration tests, not skip-if-missing**: so as not to repeat the silent skip of #18.

## Verification

All green: build, `go vet`, `gofmt`, **golangci-lint** and `go test -race`. Every dangerous behavior — deleting instead of backing up, clobbering someone else's link, leaving the link dangling when the default tenant is deleted — is pinned by a test **verified by breaking the code**. The hermetic-by-default suite still needs neither `az` nor network.

Coverage: `internal/tui` 96.8%, `internal/azure` 93.3%, `internal/config` 79.8%, `cmd` 66.8%.

---

Closes #24
Closes #25
Closes #26
Closes #27
Closes #28
Closes #29
Closes #32
Closes #33
Closes #34
Closes #35
