### PR TITLE
add: service-principal login

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,24 @@ Use `--device-code` to authenticate via device code flow instead of opening a br
 $ azsel add --device-code
 ```
 
+#### Service principal
+
+To add a tenant authenticated with a service principal — an automation or read-only identity — use `--service-principal`. This mode is non-interactive, so the name and `--tenant` are passed up front:
+
+```bash
+# With a certificate (recommended — the secret never touches a command line)
+azsel add gencat --tenant <tenant-id> \
+  --service-principal --username <app-id> --certificate ./sp-cert.pem
+
+# With a client secret, read from stdin
+printf '%s' "$CLIENT_SECRET" | azsel add gencat --tenant <tenant-id> \
+  --service-principal --username <app-id> --password-stdin
+```
+
+`--password-stdin` keeps the secret out of your shell history and out of azsel's own arguments. Note that `az login` still takes the secret as `--password` in its own arguments, so it is briefly visible in the process list; use `--certificate` where that matters. There is no plain `--password` flag, by design.
+
+Whether the service principal is read-only is its Azure role (RBAC) — the login is the same either way.
+
 ### List tenants
 
 ```bash
@@ -392,6 +410,7 @@ unset AZSEL_DEBUG
 | `azsel init --print` | Print the shell function without modifying files |
 | `azsel add` | Add a new tenant (interactive prompts + `az login`) |
 | `azsel add --device-code` | Add a tenant using device code flow (no browser) |
+| `azsel add <name> --tenant <id> --service-principal ...` | Add a tenant with a service principal (`--certificate` or `--password-stdin`) |
 | `azsel list` | List all configured tenants |
 | `azsel use <name>` | Activate a tenant by name |
 | `azsel default <name>` | Make a tenant the default for new shells |

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -78,16 +78,27 @@ func newAddCmd() *cobra.Command {
 				return err
 			}
 
-			reader := bufio.NewReader(os.Stdin)
+			// A prompt reader, created only when a prompt is actually needed.
+			// In service-principal mode nothing is prompted (name from args,
+			// tenant from --tenant), so stdin is left untouched for the secret
+			// that io.ReadAll consumes below — a buffered reader here could
+			// swallow bytes meant for it.
+			var reader *bufio.Reader
+			prompt := func(label string) string {
+				if reader == nil {
+					reader = bufio.NewReader(os.Stdin)
+				}
+				fmt.Fprint(os.Stderr, label)
+				line, _ := reader.ReadString('\n')
+				return line
+			}
 
 			// Name: a positional argument, or a prompt when omitted.
 			var name string
 			if len(args) == 1 {
 				name = strings.TrimSpace(args[0])
 			} else {
-				fmt.Fprint(os.Stderr, "Tenant name (lowercase, alphanumeric, hyphens): ")
-				line, _ := reader.ReadString('\n')
-				name = strings.TrimSpace(line)
+				name = strings.TrimSpace(prompt("Tenant name (lowercase, alphanumeric, hyphens): "))
 			}
 			if !nameRegex.MatchString(name) {
 				return fmt.Errorf("invalid name %q — use lowercase alphanumeric and hyphens only", name)
@@ -99,8 +110,7 @@ func newAddCmd() *cobra.Command {
 			// Tenant ID: the --tenant flag, or a prompt when omitted.
 			rawTenantID := tenantFlag
 			if rawTenantID == "" {
-				fmt.Fprint(os.Stderr, "Azure Tenant ID (GUID or domain): ")
-				rawTenantID, _ = reader.ReadString('\n')
+				rawTenantID = prompt("Azure Tenant ID (GUID or domain): ")
 			}
 			tenantID, err := normalizeTenantID(rawTenantID)
 			if err != nil {
@@ -122,8 +132,12 @@ func newAddCmd() *cobra.Command {
 				}
 			}
 			if servicePrincipal && certificate != "" {
-				if _, err := os.Stat(certificate); err != nil {
+				fi, err := os.Stat(certificate)
+				if err != nil {
 					return fmt.Errorf("certificate: %w", err)
+				}
+				if !fi.Mode().IsRegular() {
+					return fmt.Errorf("certificate: %s is not a regular file", certificate)
 				}
 			}
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -48,17 +49,27 @@ func normalizeTenantID(raw string) (string, error) {
 }
 
 func newAddCmd() *cobra.Command {
-	var useDeviceCode bool
+	var (
+		useDeviceCode    bool
+		tenantFlag       string
+		servicePrincipal bool
+		username         string
+		certificate      string
+		passwordStdin    bool
+	)
 
 	c := &cobra.Command{
-		Use:   "add",
+		Use:   "add [name]",
 		Short: "Add a new Azure tenant",
-		Args:  cobra.NoArgs,
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Before anything the user would have to undo. Everything below
-			// this line either asks them for input or creates directories,
-			// and all of it is wasted if az is not installed.
+			// either asks for input or creates directories, all wasted if az
+			// is not installed.
 			if err := azure.Available(); err != nil {
+				return err
+			}
+			if err := validateAddFlags(args, tenantFlag, servicePrincipal, useDeviceCode, username, certificate, passwordStdin); err != nil {
 				return err
 			}
 
@@ -69,9 +80,15 @@ func newAddCmd() *cobra.Command {
 
 			reader := bufio.NewReader(os.Stdin)
 
-			fmt.Fprint(os.Stderr, "Tenant name (lowercase, alphanumeric, hyphens): ")
-			name, _ := reader.ReadString('\n')
-			name = strings.TrimSpace(name)
+			// Name: a positional argument, or a prompt when omitted.
+			var name string
+			if len(args) == 1 {
+				name = strings.TrimSpace(args[0])
+			} else {
+				fmt.Fprint(os.Stderr, "Tenant name (lowercase, alphanumeric, hyphens): ")
+				line, _ := reader.ReadString('\n')
+				name = strings.TrimSpace(line)
+			}
 			if !nameRegex.MatchString(name) {
 				return fmt.Errorf("invalid name %q — use lowercase alphanumeric and hyphens only", name)
 			}
@@ -79,11 +96,35 @@ func newAddCmd() *cobra.Command {
 				return fmt.Errorf("tenant %q already exists", name)
 			}
 
-			fmt.Fprint(os.Stderr, "Azure Tenant ID (GUID or domain): ")
-			rawTenantID, _ := reader.ReadString('\n')
+			// Tenant ID: the --tenant flag, or a prompt when omitted.
+			rawTenantID := tenantFlag
+			if rawTenantID == "" {
+				fmt.Fprint(os.Stderr, "Azure Tenant ID (GUID or domain): ")
+				rawTenantID, _ = reader.ReadString('\n')
+			}
 			tenantID, err := normalizeTenantID(rawTenantID)
 			if err != nil {
 				return err
+			}
+
+			// Read a service-principal secret before touching disk. It comes
+			// from stdin, never a flag, so it stays out of shell history and
+			// azsel's own argv (az still takes it as --password in its argv).
+			var secret string
+			if servicePrincipal && passwordStdin {
+				b, err := io.ReadAll(os.Stdin)
+				if err != nil {
+					return fmt.Errorf("reading secret from stdin: %w", err)
+				}
+				secret = strings.TrimRight(string(b), "\r\n")
+				if secret == "" {
+					return fmt.Errorf("--password-stdin given but stdin was empty")
+				}
+			}
+			if servicePrincipal && certificate != "" {
+				if _, err := os.Stat(certificate); err != nil {
+					return fmt.Errorf("certificate: %w", err)
+				}
 			}
 
 			configDir, createdDir, err := config.EnsureTenantDir(name)
@@ -91,15 +132,9 @@ func newAddCmd() *cobra.Command {
 				return err
 			}
 
-			// From here on the tenant directory may exist without a config
-			// entry to match, so every exit has to undo it. A deferred
-			// rollback covers the paths a hand-written one keeps missing:
-			// the login, but also a failing extensions directory or a
-			// config.json that cannot be written.
-			//
-			// Only what this run created. A directory that was already there
-			// can hold valid credentials from an earlier attempt, and
-			// deleting those would turn a failed add into a lost session.
+			// From here the tenant directory may exist without a matching
+			// config entry, so every exit undoes it — but only what this run
+			// created; a pre-existing directory can hold valid credentials.
 			added := false
 			defer func() {
 				if added || !createdDir {
@@ -110,25 +145,25 @@ func newAddCmd() *cobra.Command {
 				}
 			}()
 
-			// Share extensions through the filesystem before az runs, so the
-			// login already reads and writes them in the shared directory
-			// (see #26). Reached through the default link there is no
-			// AZURE_EXTENSION_DIR to steer az, so the symlink is what makes
-			// sharing hold however the tenant is later entered.
+			// Share extensions through the filesystem before az runs (see
+			// #26): reached through the default link there is no
+			// AZURE_EXTENSION_DIR, so the symlink is what makes sharing hold.
 			if err := config.EnsureSharedExtensionsLink(configDir); err != nil {
 				return err
 			}
 
 			fmt.Fprintf(os.Stderr, "\nLogging in to tenant %q (%s)...\n", name, tenantID)
-			if err := azure.Login(tenantID, configDir, useDeviceCode); err != nil {
-				return fmt.Errorf("az login failed: %w", err)
+			var loginErr error
+			if servicePrincipal {
+				loginErr = azure.LoginServicePrincipal(tenantID, configDir, username, certificate, secret)
+			} else {
+				loginErr = azure.Login(tenantID, configDir, useDeviceCode)
+			}
+			if loginErr != nil {
+				return fmt.Errorf("az login failed: %w", loginErr)
 			}
 
-			tenant := config.Tenant{
-				Name:      name,
-				TenantID:  tenantID,
-				ConfigDir: configDir,
-			}
+			tenant := config.Tenant{Name: name, TenantID: tenantID, ConfigDir: configDir}
 			if err := cfg.AddTenant(tenant); err != nil {
 				return err
 			}
@@ -140,8 +175,45 @@ func newAddCmd() *cobra.Command {
 		},
 	}
 
-	c.Flags().BoolVar(&useDeviceCode, "device-code", false, "Use device code flow instead of opening a browser")
+	f := c.Flags()
+	f.BoolVar(&useDeviceCode, "device-code", false, "Use device code flow instead of opening a browser")
+	f.StringVar(&tenantFlag, "tenant", "", "Tenant ID (GUID or domain); prompted if omitted")
+	f.BoolVar(&servicePrincipal, "service-principal", false, "Log in with a service principal instead of interactively")
+	f.StringVarP(&username, "username", "u", "", "Service principal app (client) ID")
+	f.StringVar(&certificate, "certificate", "", "PEM file for service-principal auth")
+	f.BoolVar(&passwordStdin, "password-stdin", false, "Read the service-principal secret from stdin")
 	return c
+}
+
+// validateAddFlags enforces the service-principal contract before any prompt
+// or disk work. Service-principal mode is non-interactive: the name and
+// --tenant must be given up front, so nothing has to be prompted — which
+// matters because --password-stdin claims stdin for the secret.
+func validateAddFlags(args []string, tenantFlag string, sp, deviceCode bool, username, certificate string, passwordStdin bool) error {
+	if !sp {
+		switch {
+		case username != "", certificate != "", passwordStdin:
+			return fmt.Errorf("--username, --certificate and --password-stdin require --service-principal")
+		}
+		return nil
+	}
+	if deviceCode {
+		return fmt.Errorf("--service-principal cannot be combined with --device-code")
+	}
+	if len(args) != 1 {
+		return fmt.Errorf("service-principal mode is non-interactive: pass the tenant name as an argument")
+	}
+	if tenantFlag == "" {
+		return fmt.Errorf("service-principal mode is non-interactive: pass --tenant")
+	}
+	if username == "" {
+		return fmt.Errorf("--service-principal requires --username (the app/client ID)")
+	}
+	if (certificate != "") == passwordStdin {
+		// Both set or neither set — need exactly one.
+		return fmt.Errorf("provide exactly one of --certificate or --password-stdin")
+	}
+	return nil
 }
 
 // activationHint explains how to activate a freshly added tenant.

--- a/cmd/add_sp_test.go
+++ b/cmd/add_sp_test.go
@@ -103,7 +103,7 @@ func TestAddServicePrincipalSecretFromStdin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("az was not invoked: %v", err)
 	}
-	if !strings.Contains(string(got), "--password\nthe-secret") {
+	if !strings.Contains(string(got), "--password=the-secret") {
 		t.Errorf("secret not passed to az as --password:\n%s", got)
 	}
 }
@@ -137,5 +137,24 @@ func TestAddServicePrincipalMissingCertificate(t *testing.T) {
 	}
 	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
 		t.Error("az was invoked despite the missing certificate")
+	}
+}
+
+// A certificate path that is a directory fails fast, before az runs — os.Stat
+// alone would accept it.
+func TestAddServicePrincipalCertificateIsDirectory(t *testing.T) {
+	home := addSandbox(t)
+	sentinel := filepath.Join(home, "az-ran")
+	fakeAzureCLI(t, `: > "`+sentinel+`"; exit 0`)
+	dir := t.TempDir() // a directory, not a PEM file
+	quiet(t)
+
+	err := run(t, newAddCmd(),
+		"acme", "--tenant", testTenantID, "--service-principal", "-u", "app", "--certificate", dir)
+	if err == nil || !strings.Contains(err.Error(), "not a regular file") {
+		t.Errorf("error = %v, wanted a not-a-regular-file error", err)
+	}
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Error("az was invoked despite the certificate being a directory")
 	}
 }

--- a/cmd/add_sp_test.go
+++ b/cmd/add_sp_test.go
@@ -1,0 +1,141 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aolmosj/azsel/internal/config"
+)
+
+// The service-principal flag matrix, rejected before any prompt or disk work.
+func TestValidateAddFlags(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		tenant  string
+		sp      bool
+		device  bool
+		user    string
+		cert    string
+		pwStdin bool
+		wantErr string
+	}{
+		{name: "interactive, no sp flags", wantErr: ""},
+		{name: "sp flags without --service-principal", user: "app", wantErr: "require --service-principal"},
+		{name: "cert without --service-principal", cert: "c.pem", wantErr: "require --service-principal"},
+		{name: "sp ok with cert", args: []string{"acme"}, tenant: "t", sp: true, user: "app", cert: "c.pem", wantErr: ""},
+		{name: "sp ok with password-stdin", args: []string{"acme"}, tenant: "t", sp: true, user: "app", pwStdin: true, wantErr: ""},
+		{name: "sp with device-code", args: []string{"acme"}, tenant: "t", sp: true, user: "app", cert: "c.pem", device: true, wantErr: "cannot be combined with --device-code"},
+		{name: "sp without name arg", tenant: "t", sp: true, user: "app", cert: "c.pem", wantErr: "pass the tenant name"},
+		{name: "sp without --tenant", args: []string{"acme"}, sp: true, user: "app", cert: "c.pem", wantErr: "pass --tenant"},
+		{name: "sp without username", args: []string{"acme"}, tenant: "t", sp: true, cert: "c.pem", wantErr: "requires --username"},
+		{name: "sp with neither cert nor stdin", args: []string{"acme"}, tenant: "t", sp: true, user: "app", wantErr: "exactly one of --certificate or --password-stdin"},
+		{name: "sp with both cert and stdin", args: []string{"acme"}, tenant: "t", sp: true, user: "app", cert: "c.pem", pwStdin: true, wantErr: "exactly one of --certificate or --password-stdin"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateAddFlags(c.args, c.tenant, c.sp, c.device, c.user, c.cert, c.pwStdin)
+			if c.wantErr == "" {
+				if err != nil {
+					t.Errorf("wanted no error, got %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), c.wantErr) {
+				t.Errorf("error = %v, wanted it to contain %q", err, c.wantErr)
+			}
+		})
+	}
+}
+
+// End-to-end: a service-principal add runs az with the right flags. The fake
+// az records its argv so we can assert the passthrough.
+func TestAddServicePrincipalEndToEnd(t *testing.T) {
+	home := addSandbox(t)
+	argfile := filepath.Join(home, "az-args")
+	// The fake az writes its own arguments (one per line) to a file.
+	fakeAzureCLI(t, `printf '%s\n' "$@" > "`+argfile+`"; exit 0`)
+	cert := filepath.Join(t.TempDir(), "cert.pem")
+	if err := os.WriteFile(cert, []byte("PEM"), 0600); err != nil {
+		t.Fatalf("prep: %v", err)
+	}
+	quiet(t)
+
+	err := run(t, newAddCmd(),
+		"acme", "--tenant", testTenantID, "--service-principal", "-u", "app-123", "--certificate", cert)
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	data, err := os.ReadFile(argfile)
+	if err != nil {
+		t.Fatalf("az was not invoked: %v", err)
+	}
+	got := string(data)
+	for _, want := range []string{"login", "--service-principal", "--username", "app-123", "--certificate", cert, "--tenant", testTenantID} {
+		if !strings.Contains(got, want) {
+			t.Errorf("az args missing %q:\n%s", want, got)
+		}
+	}
+	// It was saved.
+	cfg, _ := config.Load()
+	if cfg.FindTenant("acme") == nil {
+		t.Error("tenant not saved after service-principal login")
+	}
+}
+
+// The secret is read from stdin and handed to az; azsel never puts it in a flag.
+func TestAddServicePrincipalSecretFromStdin(t *testing.T) {
+	home := addSandbox(t)
+	argfile := filepath.Join(home, "az-args")
+	fakeAzureCLI(t, `printf '%s\n' "$@" > "`+argfile+`"; exit 0`)
+	feedStdin(t, "the-secret\n")
+	quiet(t)
+
+	err := run(t, newAddCmd(),
+		"acme", "--tenant", testTenantID, "--service-principal", "-u", "app-123", "--password-stdin")
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	got, err := os.ReadFile(argfile)
+	if err != nil {
+		t.Fatalf("az was not invoked: %v", err)
+	}
+	if !strings.Contains(string(got), "--password\nthe-secret") {
+		t.Errorf("secret not passed to az as --password:\n%s", got)
+	}
+}
+
+// An empty stdin with --password-stdin is a clear error, not a login with an
+// empty secret.
+func TestAddServicePrincipalEmptyStdin(t *testing.T) {
+	addSandbox(t)
+	fakeAzureCLI(t, "exit 0")
+	feedStdin(t, "")
+	quiet(t)
+
+	err := run(t, newAddCmd(),
+		"acme", "--tenant", testTenantID, "--service-principal", "-u", "app", "--password-stdin")
+	if err == nil || !strings.Contains(err.Error(), "stdin was empty") {
+		t.Errorf("error = %v, wanted an empty-stdin error", err)
+	}
+}
+
+// A missing certificate file fails fast, before az runs.
+func TestAddServicePrincipalMissingCertificate(t *testing.T) {
+	home := addSandbox(t)
+	sentinel := filepath.Join(home, "az-ran")
+	fakeAzureCLI(t, `: > "`+sentinel+`"; exit 0`)
+	quiet(t)
+
+	err := run(t, newAddCmd(),
+		"acme", "--tenant", testTenantID, "--service-principal", "-u", "app", "--certificate", filepath.Join(home, "nope.pem"))
+	if err == nil || !strings.Contains(err.Error(), "certificate") {
+		t.Errorf("error = %v, wanted a certificate error", err)
+	}
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Error("az was invoked despite the missing certificate")
+	}
+}

--- a/internal/azure/azure.go
+++ b/internal/azure/azure.go
@@ -75,11 +75,20 @@ func Login(tenantID, configDir string, useDeviceCode bool) error {
 // stdin or env option in `az login` for it — so it is briefly visible in the
 // process list. Prefer certificate where the exposure matters.
 func LoginServicePrincipal(tenantID, configDir, appID, certificate, secret string) error {
-	args := []string{"login", "--service-principal", "--tenant", tenantID, "--username", appID}
+	// Values are joined with '=' rather than passed as separate argv tokens.
+	// az parses with argparse, which treats a value beginning with '-' (an
+	// Azure secret can) as another flag; az's own help mandates the
+	// --password=secret form for exactly that case. The '=' form is
+	// unambiguous for every value.
+	args := []string{
+		"login", "--service-principal",
+		"--tenant=" + tenantID,
+		"--username=" + appID,
+	}
 	if certificate != "" {
-		args = append(args, "--certificate", certificate)
+		args = append(args, "--certificate="+certificate)
 	} else {
-		args = append(args, "--password", secret)
+		args = append(args, "--password="+secret)
 	}
 	cmd := command(configDir, args...)
 	cmd.Stdout = os.Stderr

--- a/internal/azure/azure.go
+++ b/internal/azure/azure.go
@@ -66,3 +66,23 @@ func Login(tenantID, configDir string, useDeviceCode bool) error {
 	cmd.Stderr = os.Stderr
 	return run(cmd)
 }
+
+// LoginServicePrincipal logs a tenant in with a service principal, scoped to
+// configDir. Either certificate (a PEM path) or secret is used, never both;
+// the caller enforces that. Non-interactive, so stdin is not connected.
+//
+// With a secret, az takes it as --password in its own argv — there is no
+// stdin or env option in `az login` for it — so it is briefly visible in the
+// process list. Prefer certificate where the exposure matters.
+func LoginServicePrincipal(tenantID, configDir, appID, certificate, secret string) error {
+	args := []string{"login", "--service-principal", "--tenant", tenantID, "--username", appID}
+	if certificate != "" {
+		args = append(args, "--certificate", certificate)
+	} else {
+		args = append(args, "--password", secret)
+	}
+	cmd := command(configDir, args...)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	return run(cmd)
+}

--- a/internal/azure/azure_test.go
+++ b/internal/azure/azure_test.go
@@ -190,3 +190,40 @@ func TestCommandEnvOverridesInheritedValues(t *testing.T) {
 		t.Errorf("AZURE_CONFIG_DIR efectivo = %q, quería «/cfg/acme»", v)
 	}
 }
+
+func TestLoginServicePrincipalWithCertificate(t *testing.T) {
+	got := stubRun(t, nil)
+	if err := LoginServicePrincipal("TID", "/cfg", "app-id", "/path/cert.pem", ""); err != nil {
+		t.Fatalf("LoginServicePrincipal: %v", err)
+	}
+	want := []string{"az", "login", "--service-principal", "--tenant", "TID", "--username", "app-id", "--certificate", "/path/cert.pem"}
+	if !slices.Equal(got.cmd.Args, want) {
+		t.Errorf("args = %v, wanted %v", got.cmd.Args, want)
+	}
+	// Non-interactive: stdin is not connected.
+	if got.cmd.Stdin != nil {
+		t.Error("stdin connected for a service-principal login; should be nil")
+	}
+}
+
+func TestLoginServicePrincipalWithSecret(t *testing.T) {
+	got := stubRun(t, nil)
+	if err := LoginServicePrincipal("TID", "/cfg", "app-id", "", "s3cr3t"); err != nil {
+		t.Fatalf("LoginServicePrincipal: %v", err)
+	}
+	want := []string{"az", "login", "--service-principal", "--tenant", "TID", "--username", "app-id", "--password", "s3cr3t"}
+	if !slices.Equal(got.cmd.Args, want) {
+		t.Errorf("args = %v, wanted %v", got.cmd.Args, want)
+	}
+}
+
+// The tenant's config directory is still scoped via AZURE_CONFIG_DIR.
+func TestLoginServicePrincipalScopesConfigDir(t *testing.T) {
+	got := stubRun(t, nil)
+	if err := LoginServicePrincipal("TID", "/cfg/acme", "app", "", "x"); err != nil {
+		t.Fatalf("LoginServicePrincipal: %v", err)
+	}
+	if v, ok := envValue(got.cmd, "AZURE_CONFIG_DIR"); !ok || v != "/cfg/acme" {
+		t.Errorf("AZURE_CONFIG_DIR = %q (present=%v), wanted /cfg/acme", v, ok)
+	}
+}

--- a/internal/azure/azure_test.go
+++ b/internal/azure/azure_test.go
@@ -196,7 +196,7 @@ func TestLoginServicePrincipalWithCertificate(t *testing.T) {
 	if err := LoginServicePrincipal("TID", "/cfg", "app-id", "/path/cert.pem", ""); err != nil {
 		t.Fatalf("LoginServicePrincipal: %v", err)
 	}
-	want := []string{"az", "login", "--service-principal", "--tenant", "TID", "--username", "app-id", "--certificate", "/path/cert.pem"}
+	want := []string{"az", "login", "--service-principal", "--tenant=TID", "--username=app-id", "--certificate=/path/cert.pem"}
 	if !slices.Equal(got.cmd.Args, want) {
 		t.Errorf("args = %v, wanted %v", got.cmd.Args, want)
 	}
@@ -211,7 +211,7 @@ func TestLoginServicePrincipalWithSecret(t *testing.T) {
 	if err := LoginServicePrincipal("TID", "/cfg", "app-id", "", "s3cr3t"); err != nil {
 		t.Fatalf("LoginServicePrincipal: %v", err)
 	}
-	want := []string{"az", "login", "--service-principal", "--tenant", "TID", "--username", "app-id", "--password", "s3cr3t"}
+	want := []string{"az", "login", "--service-principal", "--tenant=TID", "--username=app-id", "--password=s3cr3t"}
 	if !slices.Equal(got.cmd.Args, want) {
 		t.Errorf("args = %v, wanted %v", got.cmd.Args, want)
 	}
@@ -225,5 +225,22 @@ func TestLoginServicePrincipalScopesConfigDir(t *testing.T) {
 	}
 	if v, ok := envValue(got.cmd, "AZURE_CONFIG_DIR"); !ok || v != "/cfg/acme" {
 		t.Errorf("AZURE_CONFIG_DIR = %q (present=%v), wanted /cfg/acme", v, ok)
+	}
+}
+
+// A secret starting with '-' must be one token joined with '=', or az's
+// argparse would read it as a flag and the login would fail.
+func TestLoginServicePrincipalSecretStartingWithDash(t *testing.T) {
+	got := stubRun(t, nil)
+	if err := LoginServicePrincipal("TID", "/cfg", "app", "", "-leadingdash"); err != nil {
+		t.Fatalf("LoginServicePrincipal: %v", err)
+	}
+	for _, a := range got.cmd.Args {
+		if a == "--password" {
+			t.Fatal("secret passed as a separate token; a '-' secret would misparse")
+		}
+	}
+	if !slices.Contains(got.cmd.Args, "--password=-leadingdash") {
+		t.Errorf("args = %v, wanted a single --password=-leadingdash token", got.cmd.Args)
 	}
 }


### PR DESCRIPTION
Adds service-principal authentication to `azsel add`. Closes #36.

## Why

`azsel add` only did interactive login (`az login --tenant`, optionally `--device-code`). No way to add a tenant with a **service principal** — the usual case for a read-only automation identity, CI, or a headless box — short of logging in by hand and editing `config.json`.

## What

```bash
# certificate (recommended)
azsel add gencat --tenant <id> --service-principal --username <app-id> --certificate cert.pem

# client secret, from stdin
printf '%s' "$SECRET" | azsel add gencat --tenant <id> --service-principal --username <app-id> --password-stdin
```

New flags on `add`: `--service-principal`, `--username/-u`, `--certificate`, `--password-stdin`, plus a positional `[name]` and `--tenant` so the flow runs without prompts. Interactive add is unchanged and also gains the positional name and `--tenant` to skip prompts.

## Design

- **Service-principal mode is non-interactive by contract**: name (positional) and `--tenant` must be given up front, so nothing is prompted — which matters because `--password-stdin` claims stdin for the secret. `validateAddFlags` enforces every combination before any prompt or disk work.
- **The secret is read from stdin, never a flag**, so it stays out of shell history and azsel's own argv. `az login` still takes it as `--password` in its own argv (briefly ps-visible) — there's no stdin/env option in `az login` for the secret — so `--certificate` is the path where that exposure matters. No plain `--password` flag, by design.
- Missing certificate file fails fast, before az runs.
- Reuses `nameRegex` and `normalizeTenantID`.

## Tests

- `azure.LoginServicePrincipal` arg construction (cert and secret), config-dir scoping, stdin not connected.
- The full validation matrix (11 cases).
- End-to-end adds with a fake `az` that records its argv: certificate passthrough, secret-from-stdin, empty-stdin error, missing-certificate fail-fast.

Hermetic suite stays green; no `az` or network needed.

## Versioning

Backward-compatible — a new opt-in path — so this is a **1.1.0**, not a break of the 1.0 interface.

Closes #36
