### PR TITLE
TUI: center the set-default confirmation as a modal

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -26,6 +26,9 @@ type Model struct {
 	confirming  bool
 	confirmName string
 	status      string
+
+	width  int
+	height int
 }
 
 func NewModel(tenants []config.Tenant, currentConfigDir, defaultName string, setDefault func(name string) (string, error)) Model {
@@ -71,6 +74,7 @@ func (m Model) Init() tea.Cmd {
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
 		h, v := lipgloss.NewStyle().Margin(1, 2).GetFrameSize()
 		m.list.SetSize(msg.Width-h, msg.Height-v)
 		return m, nil
@@ -132,14 +136,34 @@ func (m Model) View() string {
 	if m.quitting {
 		return ""
 	}
+	// The confirmation takes over the screen as a centered modal rather than
+	// trailing after the list and help bar, where it was easy to miss.
+	if m.confirming {
+		return m.confirmView()
+	}
 	body := m.list.View()
-	switch {
-	case m.confirming:
-		body += "\n\n" + confirmStyle.Render("Set "+m.confirmName+" as the default? This repoints ~/.azure. [y/N]")
-	case m.status != "":
+	if m.status != "" {
 		body += "\n\n" + statusMsgStyle.Render(m.status)
 	}
 	return appStyle.Render(body)
+}
+
+func (m Model) confirmView() string {
+	box := confirmBoxStyle.Render(lipgloss.JoinVertical(lipgloss.Left,
+		confirmTitleStyle.Render("Set "+m.confirmName+" as the default?"),
+		"",
+		"This repoints ~/.azure to this tenant.",
+		"",
+		confirmKeysStyle.Render("y")+" set default     "+confirmKeysStyle.Render("N")+" cancel",
+	))
+	// Center in the content area (terminal minus the app margin). Before the
+	// first WindowSizeMsg the size is unknown, so fall back to the bare box.
+	fh, fv := lipgloss.NewStyle().Margin(1, 2).GetFrameSize()
+	w, h := m.width-fh, m.height-fv
+	if w <= 0 || h <= 0 {
+		return appStyle.Render(box)
+	}
+	return appStyle.Render(lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, box))
 }
 
 func (m Model) Selected() *config.Tenant {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -501,3 +501,23 @@ var errTest = &testError{}
 type testError struct{}
 
 func (*testError) Error() string { return "boom" }
+
+// The confirmation is a modal that takes over the view, not a line appended
+// after the list and help bar where it was easy to miss (#38). Guard: while
+// confirming, other tenants from the list must not render.
+func TestSetDefaultConfirmIsAModalNotAppended(t *testing.T) {
+	ts := tenants() // acme (selected), globex
+	m := NewModel(ts, "", "", func(string) (string, error) { return "", nil })
+	m, _ = send(t, m, tea.WindowSizeMsg{Width: 60, Height: 20})
+	m, _ = send(t, m, keyMsg("d"))
+
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "as the default?") {
+		t.Fatalf("confirmation prompt missing:\n%s", view)
+	}
+	// globex only appears in the list, never in the modal — if it shows, the
+	// prompt is back to trailing after the list.
+	if strings.Contains(view, ts[1].Name) {
+		t.Errorf("the list still renders during confirmation (found %q):\n%s", ts[1].Name, view)
+	}
+}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -53,10 +53,22 @@ var (
 			Background(azureBlue).
 			Padding(0, 1)
 
-	confirmStyle = lipgloss.NewStyle().
-			Foreground(white).
-			Background(azureBlue).
-			Padding(0, 1)
+	// The set-default confirmation is a centered modal so it cannot be missed,
+	// however long the tenant list is.
+	confirmBoxStyle = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(azureBlue).
+			Padding(1, 3)
+
+	confirmTitleStyle = lipgloss.NewStyle().
+				Foreground(white).
+				Background(azureBlue).
+				Bold(true).
+				Padding(0, 1)
+
+	confirmKeysStyle = lipgloss.NewStyle().
+				Foreground(azureBlue).
+				Bold(true)
 
 	statusMsgStyle = lipgloss.NewStyle().
 			Foreground(azureLight)


### PR DESCRIPTION
Fixes the TUI set-default confirmation being buried at the bottom of the view. Closes #38.

## Problem

Pressing `d` to set the default appended the confirmation after `m.list.View()` — below the full tenant list *and* the help bar. On any non-trivial list it landed at the very bottom, far from the focus and reading as chrome, so users missed that the TUI was waiting for `y`/`N`.

## Fix

The confirmation now takes over the view as a bordered box centered in the terminal while confirming:

```
        ╭────────────────────────────────────────────╮
        │    Set contoso as the default?             │
        │    This repoints ~/.azure to this tenant.  │
        │    y set default     N cancel              │
        ╰────────────────────────────────────────────╯
```

Unmissable regardless of list length or terminal height. The model records the window size to center the box; before the first `WindowSizeMsg` it falls back to the bare box.

Only a rendering change — the confirmation state and control flow from #28 are untouched.

## Tests

A new test pins the placement: while confirming, other tenants from the list must not render. Verified to fail if the prompt is put back to trailing after the list. The existing `d`-key tests (ask/cancel/error/filtering-guard) stay green.

Closes #38
