### PR TITLE
Translate the test suite and config comments to English

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,9 +15,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # azsel se publica para linux y darwin (ver .goreleaser.yaml). La
-        # detección de shell y las rutas de configuración difieren entre
-        # ambos, así que conviene ejercitar los dos.
+        # azsel is published for linux and darwin (see .goreleaser.yaml).
+        # Shell detection and the configuration paths differ between both, so
+        # it is worth exercising the two of them.
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
@@ -92,7 +92,7 @@ jobs:
         run: |
           unformatted=$(gofmt -l .)
           if [ -n "$unformatted" ]; then
-            echo "Estos ficheros no están formateados:"
+            echo "These files are not formatted:"
             echo "$unformatted"
             echo
             gofmt -d .

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,10 @@
 version: "2"
 
 linters:
-  # Conjunto explícito, no el de por defecto. Cada linter está aquí porque
-  # cubre algo que `go vet` no mira. staticcheck se deja para más adelante y
-  # en un PR aparte: es el que más ruido genera de entrada y conviene que su
-  # triaje no se mezcle con el del resto.
+  # Explicit set, not the default set. Each linter is here because it covers
+  # something `go vet` does not look at. staticcheck is left for later and in
+  # a separate PR: it is the noisiest one up front and its triage should not
+  # get mixed in with the rest.
   default: none
   enable:
     - errcheck
@@ -15,10 +15,10 @@ linters:
 
   settings:
     errcheck:
-      # Toda la salida visible de azsel va a stderr, y la tabla de `list` pasa
-      # por un tabwriter cuyo Flush() sí se comprueba — que es donde aflora
-      # cualquier error de escritura. Comprobar cada Fprintf a stderr solo
-      # añadiría ruido sin cubrir nada.
+      # All of azsel's visible output goes to stderr, and the `list` table
+      # passes through a tabwriter whose Flush() is checked — which is where
+      # any write error surfaces. Checking every Fprintf to stderr would only
+      # add noise without covering anything.
       exclude-functions:
         - fmt.Fprint
         - fmt.Fprintf
@@ -26,32 +26,32 @@ linters:
 
   exclusions:
     rules:
-      # Los tests crean ficheros y directorios con permisos concretos a
-      # propósito: en varios casos el permiso *es* lo que se está probando.
+      # The tests create files and directories with specific permissions on
+      # purpose: in several cases the permission *is* what is being tested.
       - path: _test\.go
         linters:
           - gosec
 
-      # Ejecutar az con argumentos variables es la razón de ser del paquete.
-      # El binario es una constante y los argumentos van como elementos de
-      # argv, no a través de un shell, así que no hay inyección posible.
+      # Running az with variable arguments is the whole reason the package
+      # exists. The binary is a constant and the arguments go as elements of
+      # argv, not through a shell, so no injection is possible.
       - path: internal/azure/azure\.go
         linters:
           - gosec
         text: "G204"
 
-      # La ruta sale de BaseDir(), que es del propio azsel (o de AZSEL_HOME,
-      # que define el usuario para sí mismo). No hay entrada externa.
+      # The path comes from BaseDir(), which belongs to azsel itself (or from
+      # AZSEL_HOME, which the user defines for themselves). No external input.
       - path: internal/config/config\.go
         linters:
           - gosec
         text: "G304"
 
-      # G302: 0644 es la convención para un fichero rc de shell, y el flag
-      # O_CREATE solo aplica permisos cuando el fichero no existe — lo normal
-      # es que ya esté ahí.
-      # G304: la ruta la produce detectShellRC() a partir de $SHELL y $HOME
-      # del propio usuario. No hay entrada externa.
+      # G302: 0644 is the convention for a shell rc file, and the O_CREATE
+      # flag only applies permissions when the file does not exist — normally
+      # it is already there.
+      # G304: the path is produced by detectShellRC() from the user's own
+      # $SHELL and $HOME. No external input.
       - path: cmd/init\.go
         linters:
           - gosec

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,9 +15,9 @@ builds:
       - arm64
 
 archives:
-  # 'format' quedó deprecado en GoReleaser v2 a favor de 'formats', que es
-  # una lista. La action flota en "~> v2", así que mantenerlo habría roto la
-  # release en cuanto se retirase la propiedad.
+  # 'format' was deprecated in GoReleaser v2 in favor of 'formats', which is
+  # a list. The action floats on "~> v2", so keeping it would have broken the
+  # release as soon as the property was removed.
   - formats: [tar.gz]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 

--- a/cmd/add_rollback_test.go
+++ b/cmd/add_rollback_test.go
@@ -11,7 +11,7 @@ import (
 
 const testTenantID = "11111111-1111-1111-1111-111111111111"
 
-// sandbox aísla la configuración de azsel para un test.
+// sandbox isolates azsel's configuration for a test.
 func addSandbox(t *testing.T) string {
 	t.Helper()
 	home := t.TempDir()
@@ -19,7 +19,7 @@ func addSandbox(t *testing.T) string {
 	return home
 }
 
-// El caso feliz, de punta a punta con un az de mentira que sale con 0.
+// The happy path, end-to-end with a fake az that exits 0.
 func TestAddSucceeds(t *testing.T) {
 	home := addSandbox(t)
 	fakeAzureCLI(t, "exit 0")
@@ -31,7 +31,7 @@ func TestAddSucceeds(t *testing.T) {
 	}
 
 	if fi, err := os.Stat(filepath.Join(home, "tenants", "acme")); err != nil || !fi.IsDir() {
-		t.Fatalf("no se creó el directorio del tenant: %v", err)
+		t.Fatalf("tenant directory was not created: %v", err)
 	}
 	cfg, err := config.Load()
 	if err != nil {
@@ -39,14 +39,14 @@ func TestAddSucceeds(t *testing.T) {
 	}
 	got := cfg.FindTenant("acme")
 	if got == nil {
-		t.Fatal("el tenant no se guardó en config.json")
+		t.Fatal("the tenant was not saved to config.json")
 	}
 	if got.TenantID != testTenantID {
-		t.Errorf("TenantID = %q, quería %q", got.TenantID, testTenantID)
+		t.Errorf("TenantID = %q, wanted %q", got.TenantID, testTenantID)
 	}
 }
 
-// El fallo que motiva esta issue: az login falla y el directorio se queda.
+// The failure that motivates this issue: az login fails and the directory stays.
 func TestAddRemovesDirectoryItCreatedWhenLoginFails(t *testing.T) {
 	home := addSandbox(t)
 	fakeAzureCLI(t, "exit 1")
@@ -54,34 +54,34 @@ func TestAddRemovesDirectoryItCreatedWhenLoginFails(t *testing.T) {
 	quiet(t)
 
 	if err := run(t, newAddCmd()); err == nil {
-		t.Fatal("add devolvió nil con az login fallando")
+		t.Fatal("add returned nil with az login failing")
 	}
 
 	if _, err := os.Stat(filepath.Join(home, "tenants", "acme")); !os.IsNotExist(err) {
-		t.Errorf("quedó el directorio huérfano (err=%v)", err)
+		t.Errorf("orphaned directory was left behind (err=%v)", err)
 	}
 	cfg, err := config.Load()
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
 	if cfg.FindTenant("acme") != nil {
-		t.Error("config.json quedó con un tenant cuyo login no completó")
+		t.Error("config.json was left with a tenant whose login did not complete")
 	}
 }
 
-// El contrapunto, y lo que hace peligroso este arreglo si se hace mal: un
-// directorio preexistente puede contener credenciales válidas de un intento
-// anterior. Un login fallido no debe destruirlas.
+// The counterpoint, and what makes this fix dangerous if done wrong: a
+// preexisting directory may contain valid credentials from an earlier
+// attempt. A failed login must not destroy them.
 func TestAddKeepsPreexistingDirectoryWhenLoginFails(t *testing.T) {
 	home := addSandbox(t)
 
 	tenantDir := filepath.Join(home, "tenants", "acme")
 	if err := os.MkdirAll(tenantDir, 0755); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	token := filepath.Join(tenantDir, "msal_token_cache.json")
-	if err := os.WriteFile(token, []byte(`{"credenciales":"valiosas"}`), 0600); err != nil {
-		t.Fatalf("preparando: %v", err)
+	if err := os.WriteFile(token, []byte(`{"credentials":"valuable"}`), 0600); err != nil {
+		t.Fatalf("setup: %v", err)
 	}
 
 	fakeAzureCLI(t, "exit 1")
@@ -89,23 +89,23 @@ func TestAddKeepsPreexistingDirectoryWhenLoginFails(t *testing.T) {
 	quiet(t)
 
 	if err := run(t, newAddCmd()); err == nil {
-		t.Fatal("add devolvió nil con az login fallando")
+		t.Fatal("add returned nil with az login failing")
 	}
 
 	if _, err := os.Stat(tenantDir); err != nil {
-		t.Fatalf("se borró un directorio preexistente: %v", err)
+		t.Fatalf("a preexisting directory was deleted: %v", err)
 	}
 	data, err := os.ReadFile(token)
 	if err != nil {
-		t.Fatalf("se borraron las credenciales preexistentes: %v", err)
+		t.Fatalf("preexisting credentials were deleted: %v", err)
 	}
-	if string(data) != `{"credenciales":"valiosas"}` {
-		t.Errorf("las credenciales cambiaron: %s", data)
+	if string(data) != `{"credentials":"valuable"}` {
+		t.Errorf("the credentials changed: %s", data)
 	}
 }
 
-// Un nombre inválido debe rechazarse sin crear nada y sin llegar a pedir el
-// tenant ID.
+// An invalid name should be rejected without creating anything and without
+// getting as far as asking for the tenant ID.
 func TestAddRejectsInvalidNameWithoutTouchingDisk(t *testing.T) {
 	home := addSandbox(t)
 	fakeAzureCLI(t, "exit 0")
@@ -113,44 +113,44 @@ func TestAddRejectsInvalidNameWithoutTouchingDisk(t *testing.T) {
 	output := quiet(t)
 
 	if err := run(t, newAddCmd()); err == nil {
-		t.Fatal("add aceptó un nombre inválido")
+		t.Fatal("add accepted an invalid name")
 	}
 	if _, err := os.Stat(filepath.Join(home, "tenants")); !os.IsNotExist(err) {
-		t.Error("se creó el directorio de tenants pese al nombre inválido")
+		t.Error("the tenants directory was created despite the invalid name")
 	}
-	// El offset de stdin no sirve para comprobar esto: bufio.Reader lee por
-	// bloques, no por líneas. Lo que sí prueba que no se siguió adelante es
-	// que el segundo prompt nunca se imprimió.
+	// The stdin offset is no good for checking this: bufio.Reader reads in
+	// blocks, not lines. What does prove it didn't go ahead is that the
+	// second prompt was never printed.
 	if got := output(); strings.Contains(got, "Azure Tenant ID") {
-		t.Errorf("se pidió el tenant ID pese al nombre inválido:\n%s", got)
+		t.Errorf("the tenant ID was requested despite the invalid name:\n%s", got)
 	}
 }
 
-// Un tenant ID mal pegado debe morir aquí, no en Azure: el error de azsel es
-// más claro y no cuesta un viaje al navegador.
+// A badly pasted tenant ID should die here, not at Azure: azsel's error is
+// clearer and doesn't cost a trip to the browser.
 func TestAddRejectsInvalidTenantIDBeforeCallingAz(t *testing.T) {
 	home := addSandbox(t)
 	fakeAzureCLI(t, `touch "$AZSEL_HOME/az-called"; exit 0`)
-	feedStdin(t, "acme\nno-soy-un-tenant\n")
+	feedStdin(t, "acme\nnot-a-tenant\n")
 	quiet(t)
 
 	err := run(t, newAddCmd())
 	if err == nil {
-		t.Fatal("add aceptó un tenant ID inválido")
+		t.Fatal("add accepted an invalid tenant ID")
 	}
 	if !strings.Contains(err.Error(), "invalid tenant ID") {
-		t.Errorf("error = %q, quería que explicara el formato", err)
+		t.Errorf("error = %q, wanted it to explain the format", err)
 	}
 	if _, err := os.Stat(filepath.Join(home, "az-called")); !os.IsNotExist(err) {
-		t.Error("se invocó az pese al tenant ID inválido")
+		t.Error("az was invoked despite the invalid tenant ID")
 	}
 	if _, err := os.Stat(filepath.Join(home, "tenants", "acme")); !os.IsNotExist(err) {
-		t.Error("se creó el directorio del tenant pese al tenant ID inválido")
+		t.Error("the tenant directory was created despite the invalid tenant ID")
 	}
 }
 
-// La normalización tiene que llegar hasta config.json: si no, el mismo tenant
-// escrito con distinta caja aparecería como dos entradas distintas.
+// Normalization has to reach config.json: otherwise the same tenant written
+// with different casing would appear as two distinct entries.
 func TestAddStoresTenantIDNormalized(t *testing.T) {
 	addSandbox(t)
 	fakeAzureCLI(t, "exit 0")
@@ -166,56 +166,57 @@ func TestAddStoresTenantIDNormalized(t *testing.T) {
 	}
 	tenant := cfg.FindTenant("acme")
 	if tenant == nil {
-		t.Fatal("no se guardó el tenant")
+		t.Fatal("the tenant was not saved")
 	}
 	if want := "aabbccdd-1122-3344-5566-778899aabbcc"; tenant.TenantID != want {
-		t.Errorf("TenantID = %q, quería %q", tenant.TenantID, want)
+		t.Errorf("TenantID = %q, wanted %q", tenant.TenantID, want)
 	}
 }
 
-// El rollback no puede cubrir solo el login. Entre crear el directorio del
-// tenant y escribir config.json hay más formas de salir, y todas dejan el
-// mismo huérfano. Esta reproduce una real: un fichero ocupando la ruta del
-// directorio de extensiones, que EnsureExtensionsDir rechaza desde #7.
+// The rollback can't cover only the login. Between creating the tenant
+// directory and writing config.json there are more ways to exit, and they all
+// leave the same orphan behind. This one reproduces a real case: a file
+// occupying the path of the extensions directory, which EnsureExtensionsDir
+// rejects since #7.
 func TestAddRemovesDirectoryWhenExtensionsDirFails(t *testing.T) {
 	home := addSandbox(t)
 	if err := os.WriteFile(filepath.Join(home, "extensions"), nil, 0644); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	fakeAzureCLI(t, "exit 0")
 	feedStdin(t, "acme\n"+testTenantID+"\n")
 	quiet(t)
 
 	if err := run(t, newAddCmd()); err == nil {
-		t.Fatal("add devolvió nil con el directorio de extensiones bloqueado")
+		t.Fatal("add returned nil with the extensions directory blocked")
 	}
 	if _, err := os.Stat(filepath.Join(home, "tenants", "acme")); !os.IsNotExist(err) {
-		t.Errorf("quedó el directorio huérfano (err=%v)", err)
+		t.Errorf("orphaned directory was left behind (err=%v)", err)
 	}
 }
 
-// Y tampoco puede dejarlo si falla el guardado de config.json: un tenant con
-// directorio pero sin entrada es exactamente el estado que #9 elimina.
+// And it can't leave it behind if saving config.json fails either: a tenant
+// with a directory but no entry is exactly the state that #9 eliminates.
 //
-// Llegar hasta el Save requiere cuidado. Poner un directorio en la ruta de
-// config.json no vale: Load falla al arrancar el comando, antes de que se
-// cree nada, y el test pasaría sin haber ejercitado nada. Lo que se hace es
-// dejar tenants/ y extensions/ ya creados y volver ~/.azsel de solo lectura,
-// de modo que todo tenga éxito hasta la escritura final.
+// Reaching the Save requires care. Putting a directory at config.json's path
+// won't do: Load fails when the command starts, before anything is created,
+// and the test would pass without having exercised anything. What we do is
+// leave tenants/ and extensions/ already created and turn ~/.azsel
+// read-only, so that everything succeeds up to the final write.
 func TestAddRemovesDirectoryWhenConfigCannotBeSaved(t *testing.T) {
 	if os.Geteuid() == 0 {
-		t.Skip("root ignora los permisos de fichero")
+		t.Skip("root ignores file permissions")
 	}
 	home := addSandbox(t)
 	for _, dir := range []string{"tenants", "extensions"} {
 		if err := os.MkdirAll(filepath.Join(home, dir), 0755); err != nil {
-			t.Fatalf("preparando: %v", err)
+			t.Fatalf("setup: %v", err)
 		}
 	}
 	if err := os.Chmod(home, 0555); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
-	// Devolver el permiso de escritura para que t.TempDir pueda limpiar.
+	// Restore write permission so that t.TempDir can clean up.
 	t.Cleanup(func() { _ = os.Chmod(home, 0755) })
 
 	fakeAzureCLI(t, "exit 0")
@@ -223,9 +224,9 @@ func TestAddRemovesDirectoryWhenConfigCannotBeSaved(t *testing.T) {
 	quiet(t)
 
 	if err := run(t, newAddCmd()); err == nil {
-		t.Fatal("add devolvió nil sin poder guardar la configuración")
+		t.Fatal("add returned nil despite being unable to save the configuration")
 	}
 	if _, err := os.Stat(filepath.Join(home, "tenants", "acme")); !os.IsNotExist(err) {
-		t.Errorf("quedó el directorio huérfano (err=%v)", err)
+		t.Errorf("orphaned directory was left behind (err=%v)", err)
 	}
 }

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -2,40 +2,40 @@ package cmd
 
 import "testing"
 
-// nameRegex decide qué nombres de tenant se aceptan. El nombre acaba siendo
-// un directorio bajo ~/.azsel/tenants/, así que la restricción no es
-// cosmética: filtra separadores de ruta y espacios.
+// nameRegex decides which tenant names are accepted. The name ends up being
+// a directory under ~/.azsel/tenants/, so the restriction is not cosmetic:
+// it filters out path separators and spaces.
 func TestNameRegex(t *testing.T) {
 	cases := []struct {
 		name  string
 		valid bool
 		why   string
 	}{
-		{"a", true, "un solo carácter"},
-		{"acme", true, "minúsculas"},
-		{"acme-corp", true, "guión interior"},
-		{"client-1", true, "dígitos"},
-		{"1", true, "solo dígito"},
-		{"a-b-c-d", true, "varios guiones"},
+		{"a", true, "a single character"},
+		{"acme", true, "lowercase"},
+		{"acme-corp", true, "interior hyphen"},
+		{"client-1", true, "digits"},
+		{"1", true, "digit only"},
+		{"a-b-c-d", true, "several hyphens"},
 
-		{"", false, "vacío"},
-		{"-acme", false, "empieza por guión"},
-		{"acme-", false, "acaba en guión"},
-		{"-", false, "solo un guión"},
-		{"ACME", false, "mayúsculas"},
-		{"Acme", false, "mayúscula inicial"},
-		{"acme_corp", false, "guión bajo"},
-		{"acme corp", false, "espacio"},
-		{"acme.corp", false, "punto"},
-		{"acme/corp", false, "separador de ruta"},
-		{"..", false, "recorrido de directorios"},
-		{"acmé", false, "carácter acentuado"},
-		{"acme\n", false, "salto de línea"},
+		{"", false, "empty"},
+		{"-acme", false, "starts with a hyphen"},
+		{"acme-", false, "ends in a hyphen"},
+		{"-", false, "just a hyphen"},
+		{"ACME", false, "uppercase"},
+		{"Acme", false, "leading uppercase"},
+		{"acme_corp", false, "underscore"},
+		{"acme corp", false, "space"},
+		{"acme.corp", false, "dot"},
+		{"acme/corp", false, "path separator"},
+		{"..", false, "directory traversal"},
+		{"acmé", false, "accented character"},
+		{"acme\n", false, "newline"},
 	}
 
 	for _, c := range cases {
 		if got := nameRegex.MatchString(c.name); got != c.valid {
-			t.Errorf("nameRegex(%q) = %v, quería %v (%s)", c.name, got, c.valid, c.why)
+			t.Errorf("nameRegex(%q) = %v, wanted %v (%s)", c.name, got, c.valid, c.why)
 		}
 	}
 }

--- a/cmd/az_required_test.go
+++ b/cmd/az_required_test.go
@@ -31,7 +31,7 @@ func quiet(t *testing.T) func() string {
 	path := filepath.Join(t.TempDir(), "output")
 	f, err := os.Create(path)
 	if err != nil {
-		t.Fatalf("creando el fichero de salida: %v", err)
+		t.Fatalf("creating the output file: %v", err)
 	}
 	outOrig, errOrig := os.Stdout, os.Stderr
 	os.Stdout, os.Stderr = f, f
@@ -42,7 +42,7 @@ func quiet(t *testing.T) func() string {
 	return func() string {
 		data, err := os.ReadFile(path)
 		if err != nil {
-			t.Fatalf("leyendo la salida: %v", err)
+			t.Fatalf("reading the output: %v", err)
 		}
 		return string(data)
 	}
@@ -57,52 +57,52 @@ func run(t *testing.T, c *cobra.Command, args ...string) error {
 	return c.Execute()
 }
 
-// El coste de que az falte debe ser el mensaje y nada más. Antes el usuario
-// escribía nombre y tenant ID, se creaba el directorio del tenant, y solo
-// entonces reventaba con el error crudo de Go.
+// The cost of az being missing should be the message and nothing more. It
+// used to be that the user typed name and tenant ID, the tenant directory was
+// created, and only then it blew up with Go's raw error.
 func TestAddFailsBeforeAskingAnything(t *testing.T) {
 	home := withoutAzureCLI(t)
 	quiet(t)
 
-	// Lo que el usuario habría tecleado si se le hubiera preguntado.
+	// What the user would have typed if they had been asked.
 	f := feedStdin(t, "acme\n11111111-1111-1111-1111-111111111111\n")
 
 	err := run(t, newAddCmd())
 	if err == nil {
-		t.Fatal("add devolvió nil sin az instalado")
+		t.Fatal("add returned nil without az installed")
 	}
 	if !strings.Contains(err.Error(), "Azure CLI") {
-		t.Errorf("error = %q, quería que nombrara Azure CLI", err)
+		t.Errorf("error = %q, wanted it to name Azure CLI", err)
 	}
 	if !strings.Contains(err.Error(), "install") {
-		t.Errorf("error = %q, quería que dijera cómo instalarlo", err)
+		t.Errorf("error = %q, wanted it to say how to install it", err)
 	}
 
-	// Nada leído de stdin: no se llegó a preguntar.
+	// Nothing read from stdin: it never got as far as asking.
 	if pos, _ := f.Seek(0, io.SeekCurrent); pos != 0 {
-		t.Errorf("se consumió stdin antes de comprobar az (offset %d)", pos)
+		t.Errorf("stdin was consumed before checking az (offset %d)", pos)
 	}
-	// Y nada creado en disco.
+	// And nothing created on disk.
 	if entries, err := os.ReadDir(filepath.Join(home, "tenants")); err == nil && len(entries) > 0 {
-		t.Errorf("se crearon %d directorios de tenant pese al fallo", len(entries))
+		t.Errorf("%d tenant directories were created despite the failure", len(entries))
 	}
 }
 
-// Solo add necesita az. El resto debe seguir funcionando en una máquina sin
-// Azure CLI — consultar tenants o cambiar de uno a otro no invoca nada.
+// Only add needs az. The rest must keep working on a machine without the
+// Azure CLI — listing tenants or switching between them invokes nothing.
 func TestCommandsThatDoNotNeedAzureCLI(t *testing.T) {
 	home := withoutAzureCLI(t)
 	quiet(t)
 
 	tenantDir := filepath.Join(home, "tenants", "acme")
 	if err := os.MkdirAll(tenantDir, 0755); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	cfg := &config.Config{Tenants: []config.Tenant{
 		{Name: "acme", TenantID: "11111111-1111-1111-1111-111111111111", ConfigDir: tenantDir},
 	}}
 	if err := config.Save(cfg); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 
 	cases := []struct {
@@ -118,23 +118,23 @@ func TestCommandsThatDoNotNeedAzureCLI(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			if err := run(t, c.cmd, c.args...); err != nil {
-				t.Errorf("%s falló sin az instalado: %v", c.name, err)
+				t.Errorf("%s failed without az installed: %v", c.name, err)
 			}
 		})
 	}
 }
 
-// feedStdin conecta os.Stdin a un fichero con lo que el usuario teclearía, y
-// devuelve el descriptor para poder comprobar cuánto se ha llegado a leer.
+// feedStdin connects os.Stdin to a file with what the user would type, and
+// returns the descriptor so we can check how much has been read.
 func feedStdin(t *testing.T, content string) *os.File {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "stdin")
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
-		t.Fatalf("preparando stdin: %v", err)
+		t.Fatalf("setting up stdin: %v", err)
 	}
 	f, err := os.Open(path)
 	if err != nil {
-		t.Fatalf("abriendo stdin falso: %v", err)
+		t.Fatalf("opening the fake stdin: %v", err)
 	}
 	orig := os.Stdin
 	os.Stdin = f
@@ -145,19 +145,19 @@ func feedStdin(t *testing.T, content string) *os.File {
 	return f
 }
 
-// fakeAzureCLI pone un az de mentira delante del PATH con el cuerpo indicado.
-// Deja ejercitar el camino real —Available lo encuentra, Login lo ejecuta—
-// sin costuras y sin tocar Azure.
+// fakeAzureCLI puts a fake az in front of the PATH with the given body. It
+// lets us exercise the real path —Available finds it, Login runs it— without
+// seams and without touching Azure.
 //
-// Se antepone en vez de reemplazar el PATH: reemplazarlo dejaba al script sin
-// utilidades básicas, de modo que un cuerpo como `touch centinela` fallaba en
-// silencio con «command not found» y cualquier aserción sobre el centinela
-// resultaba vacía. Anteponerlo basta para que el az de mentira gane.
+// It's prepended rather than replacing the PATH: replacing it left the script
+// without basic utilities, so that a body like `touch sentinel` failed
+// silently with «command not found» and any assertion about the sentinel came
+// out empty. Prepending is enough for the fake az to win.
 func fakeAzureCLI(t *testing.T, body string) {
 	t.Helper()
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "az"), []byte("#!/bin/sh\n"+body+"\n"), 0755); err != nil {
-		t.Fatalf("escribiendo el az falso: %v", err)
+		t.Fatalf("writing the fake az: %v", err)
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }

--- a/cmd/default_test.go
+++ b/cmd/default_test.go
@@ -18,12 +18,12 @@ func defaultSandbox(t *testing.T, tenants ...string) string {
 	for _, name := range tenants {
 		dir, _, err := config.EnsureTenantDir(name)
 		if err != nil {
-			t.Fatalf("preparando: %v", err)
+			t.Fatalf("setup: %v", err)
 		}
 		cfg.Tenants = append(cfg.Tenants, config.Tenant{Name: name, ConfigDir: dir})
 	}
 	if err := config.Save(cfg); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	return home
 }
@@ -36,13 +36,13 @@ func TestDefaultSetCreatesLink(t *testing.T) {
 	}
 	target, err := os.Readlink(filepath.Join(home, ".azure"))
 	if err != nil {
-		t.Fatalf("~/.azure no es enlace: %v", err)
+		t.Fatalf("~/.azure is not a link: %v", err)
 	}
 	if !strings.HasSuffix(target, filepath.Join("tenants", "contoso")) {
-		t.Errorf("~/.azure -> %q, quería el tenant contoso", target)
+		t.Errorf("~/.azure -> %q, wanted the contoso tenant", target)
 	}
 	if got := out(); !strings.Contains(got, "Default tenant set") {
-		t.Errorf("salida = %q", got)
+		t.Errorf("output = %q", got)
 	}
 }
 
@@ -50,19 +50,19 @@ func TestDefaultSetBacksUpRealAzure(t *testing.T) {
 	home := defaultSandbox(t, "contoso")
 	azure := filepath.Join(home, ".azure")
 	if err := os.MkdirAll(azure, 0755); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(azure, "tok"), []byte("x"), 0600); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	out := quiet(t)
 	if err := run(t, newDefaultCmd(), "contoso"); err != nil {
 		t.Fatalf("default: %v", err)
 	}
 	if got := out(); !strings.Contains(got, "Moved your existing ~/.azure") {
-		t.Errorf("no se informó del backup: %q", got)
+		t.Errorf("the backup was not reported: %q", got)
 	}
-	// El backup existe y conserva el contenido.
+	// The backup exists and keeps its content.
 	entries, err := os.ReadDir(filepath.Join(home, ".azsel", "backups"))
 	if err != nil || len(entries) != 1 {
 		t.Fatalf("backups = %v (err %v)", entries, err)
@@ -76,7 +76,7 @@ func TestDefaultShow(t *testing.T) {
 		t.Fatalf("default: %v", err)
 	}
 	if got := out(); !strings.Contains(got, "No default set") {
-		t.Errorf("salida = %q, quería «No default set»", got)
+		t.Errorf("output = %q, wanted «No default set»", got)
 	}
 }
 
@@ -91,7 +91,7 @@ func TestDefaultShowWhenSet(t *testing.T) {
 		t.Fatalf("show: %v", err)
 	}
 	if got := out(); !strings.Contains(got, "Default tenant: contoso") {
-		t.Errorf("salida = %q", got)
+		t.Errorf("output = %q", got)
 	}
 }
 
@@ -106,17 +106,17 @@ func TestDefaultClear(t *testing.T) {
 		t.Fatalf("clear: %v", err)
 	}
 	if _, err := os.Lstat(filepath.Join(home, ".azure")); !os.IsNotExist(err) {
-		t.Error("~/.azure sigue existiendo tras --clear")
+		t.Error("~/.azure still exists after --clear")
 	}
 	if got := out(); !strings.Contains(got, "Default cleared") {
-		t.Errorf("salida = %q", got)
+		t.Errorf("output = %q", got)
 	}
 }
 
 func TestDefaultClearReportsBackup(t *testing.T) {
 	home := defaultSandbox(t, "contoso")
 	if err := os.MkdirAll(filepath.Join(home, ".azure"), 0755); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	quiet(t)
 	if err := run(t, newDefaultCmd(), "contoso"); err != nil {
@@ -127,15 +127,15 @@ func TestDefaultClearReportsBackup(t *testing.T) {
 		t.Fatalf("clear: %v", err)
 	}
 	if got := out(); !strings.Contains(got, "Restore it with:") {
-		t.Errorf("clear no explicó cómo restaurar: %q", got)
+		t.Errorf("clear did not explain how to restore: %q", got)
 	}
 }
 
 func TestDefaultRejectsUnknownTenant(t *testing.T) {
 	defaultSandbox(t, "contoso")
 	quiet(t)
-	if err := run(t, newDefaultCmd(), "fantasma"); err == nil {
-		t.Fatal("default aceptó un tenant inexistente")
+	if err := run(t, newDefaultCmd(), "ghost"); err == nil {
+		t.Fatal("default accepted a nonexistent tenant")
 	}
 }
 
@@ -143,26 +143,26 @@ func TestDefaultClearWithNameIsError(t *testing.T) {
 	defaultSandbox(t, "contoso")
 	quiet(t)
 	if err := run(t, newDefaultCmd(), "contoso", "--clear"); err == nil {
-		t.Fatal("default --clear con nombre debería fallar")
+		t.Fatal("default --clear with a name should fail")
 	}
 }
 
-// Mostrar un enlace roto debe explicar el problema, no fingir normalidad.
+// Showing a broken link should explain the problem, not fake normality.
 func TestDefaultShowBrokenLink(t *testing.T) {
 	home := defaultSandbox(t, "contoso")
 	quiet(t)
 	if err := run(t, newDefaultCmd(), "contoso"); err != nil {
 		t.Fatalf("set: %v", err)
 	}
-	// Rompemos el enlace borrando el tenant a mano (sin pasar por remove).
+	// We break the link by deleting the tenant by hand (without going through remove).
 	if err := os.RemoveAll(filepath.Join(home, ".azsel", "tenants", "contoso")); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	out := quiet(t)
 	if err := run(t, newDefaultCmd()); err != nil {
 		t.Fatalf("show: %v", err)
 	}
 	if got := out(); !strings.Contains(got, "broken symlink") {
-		t.Errorf("no se avisó del enlace roto: %q", got)
+		t.Errorf("the broken link was not reported: %q", got)
 	}
 }

--- a/cmd/hint_test.go
+++ b/cmd/hint_test.go
@@ -9,91 +9,91 @@ import (
 	"github.com/aolmosj/azsel/internal/config"
 )
 
-// El mensaje sugería `eval $(azsel use NAME)`, que no hace nada: use escribe
-// el snippet en un fichero y reporta por stderr, así que la sustitución de
-// comandos captura la cadena vacía y `eval ""` es un no-op.
+// The message suggested `eval $(azsel use NAME)`, which does nothing: use
+// writes the snippet to a file and reports on stderr, so the command
+// substitution captures the empty string and `eval ""` is a no-op.
 func TestActivationHintNeverSuggestsEval(t *testing.T) {
 	for _, active := range []bool{true, false} {
 		got := activationHint("acme", active)
 		if strings.Contains(got, "eval") {
-			t.Errorf("integración=%v: el mensaje sigue sugiriendo eval:\n%s", active, got)
+			t.Errorf("integration=%v: the message still suggests eval:\n%s", active, got)
 		}
 		if !strings.Contains(got, "azsel use acme") {
-			t.Errorf("integración=%v: falta la orden real:\n%s", active, got)
+			t.Errorf("integration=%v: the real command is missing:\n%s", active, got)
 		}
 	}
 }
 
-// Con la integración activa el mensaje debe ser una sola instrucción, sin
-// ruido: el usuario ya lo tiene todo montado.
+// With integration active the message should be a single instruction, without
+// noise: the user already has everything set up.
 func TestActivationHintIsTerseWhenIntegrationActive(t *testing.T) {
 	got := activationHint("acme", true)
 	if want := "To activate: azsel use acme\n"; got != want {
-		t.Errorf("mensaje = %q, quería %q", got, want)
+		t.Errorf("message = %q, wanted %q", got, want)
 	}
 }
 
-// Sin integración, `azsel use` no puede alcanzar el shell del usuario. Hay que
-// decirlo, no dejar que lo descubra por su cuenta.
+// Without integration, `azsel use` can't reach the user's shell. It has to be
+// said, not left for them to discover on their own.
 func TestActivationHintWarnsWithoutIntegration(t *testing.T) {
 	got := activationHint("acme", false)
 	if !strings.Contains(got, "azsel init") {
-		t.Errorf("el aviso no menciona 'azsel init':\n%s", got)
+		t.Errorf("the warning does not mention 'azsel init':\n%s", got)
 	}
 	if !strings.Contains(got, "AZURE_CONFIG_DIR") {
-		t.Errorf("el aviso no explica la consecuencia:\n%s", got)
+		t.Errorf("the warning does not explain the consequence:\n%s", got)
 	}
 }
 
-// El nombre se interpola, no se pierde.
+// The name is interpolated, not lost.
 func TestActivationHintUsesTenantName(t *testing.T) {
 	if got := activationHint("globex-prod", true); !strings.Contains(got, "globex-prod") {
-		t.Errorf("mensaje = %q, quería el nombre del tenant", got)
+		t.Errorf("message = %q, wanted the tenant name", got)
 	}
 }
 
-// `command azsel add` esquiva el wrapper a propósito, igual que cualquier
-// script. Mirar solo AZSEL_SWITCH_FILE le decía a un usuario correctamente
-// configurado que ejecutara `azsel init`, que respondería "already
-// configured" y lo dejaría sin salida.
+// `command azsel add` skips the wrapper on purpose, just like any script.
+// Looking only at AZSEL_SWITCH_FILE told a correctly configured user to run
+// `azsel init`, which would answer "already configured" and leave them
+// without a way out.
 func TestShellIntegrationInstalled(t *testing.T) {
-	t.Run("variable del wrapper presente", func(t *testing.T) {
+	t.Run("wrapper variable present", func(t *testing.T) {
 		t.Setenv(config.EnvSwitchFile, "/tmp/.switch.1")
 		if !shellIntegrationInstalled() {
-			t.Error("no se detectó la integración con la variable definida")
+			t.Error("integration was not detected with the variable set")
 		}
 	})
 
-	t.Run("wrapper esquivado pero rc configurado", func(t *testing.T) {
+	t.Run("wrapper skipped but rc configured", func(t *testing.T) {
 		home := t.TempDir()
 		t.Setenv("HOME", home)
 		t.Setenv("SHELL", "/bin/zsh")
 		t.Setenv(config.EnvSwitchFile, "")
 		if err := os.WriteFile(filepath.Join(home, ".zshrc"),
 			[]byte("\n"+initLine+"\n"), 0644); err != nil {
-			t.Fatalf("preparando: %v", err)
+			t.Fatalf("setup: %v", err)
 		}
 		if !shellIntegrationInstalled() {
-			t.Error("no se detectó la integración leyendo el rc")
+			t.Error("integration was not detected by reading the rc")
 		}
 	})
 
-	t.Run("sin integración", func(t *testing.T) {
+	t.Run("without integration", func(t *testing.T) {
 		home := t.TempDir()
 		t.Setenv("HOME", home)
 		t.Setenv("SHELL", "/bin/zsh")
 		t.Setenv(config.EnvSwitchFile, "")
 		if shellIntegrationInstalled() {
-			t.Error("se detectó integración donde no la hay")
+			t.Error("integration was detected where there is none")
 		}
 	})
 
-	t.Run("shell no soportado", func(t *testing.T) {
+	t.Run("unsupported shell", func(t *testing.T) {
 		t.Setenv("HOME", t.TempDir())
 		t.Setenv("SHELL", "/usr/bin/fish")
 		t.Setenv(config.EnvSwitchFile, "")
 		if shellIntegrationInstalled() {
-			t.Error("se detectó integración en un shell no soportado")
+			t.Error("integration was detected in an unsupported shell")
 		}
 	})
 }

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 )
 
-// shells devuelve los intérpretes en los que azsel instala su función
-// (detectShellRC contempla zsh y bash), saltando los que no estén presentes.
-// La función se instala en ambos, así que debe funcionar en ambos: #3 nació
-// justo de una construcción exclusiva de zsh metida en un fichero que también
-// acaba en .bashrc.
+// shells returns the interpreters azsel installs its function into
+// (detectShellRC covers zsh and bash), skipping the ones that aren't present.
+// The function is installed into both, so it must work in both: #3 was born
+// precisely from a zsh-only construct placed in a file that also ends up in
+// .bashrc.
 func shells(t *testing.T) []string {
 	t.Helper()
 	seen := map[string]bool{}
@@ -39,7 +39,7 @@ func shells(t *testing.T) []string {
 	add("/bin/bash")
 
 	if len(found) == 0 {
-		t.Skip("ni bash ni zsh disponibles")
+		t.Skip("neither bash nor zsh available")
 	}
 	return found
 }
@@ -50,23 +50,23 @@ func shellLabel(path string) string {
 	return strings.ReplaceAll(strings.TrimPrefix(path, "/"), "/", "_")
 }
 
-// runShellFunc evalúa la función de shell instalada por `azsel init --print`
-// en un intérprete real, con un azsel de mentira en el PATH que escribe lo
-// que se le indique en $AZSEL_SWITCH_FILE. Devuelve la salida del script.
+// runShellFunc evaluates the shell function installed by `azsel init --print`
+// in a real interpreter, with a fake azsel on the PATH that writes whatever
+// it's told to $AZSEL_SWITCH_FILE. Returns the script's output.
 //
-// Es el único test que ejercita el mecanismo central de azsel de punta a
-// punta: el binario no puede tocar el entorno del shell padre, así que todo
-// depende de que esta función haga el source correctamente.
+// It's the only test that exercises azsel's central mechanism end-to-end:
+// the binary can't touch the parent shell's environment, so everything
+// depends on this function sourcing correctly.
 func runShellFunc(t *testing.T, shell, home, stubBody, script string, extraEnv ...string) string {
 	t.Helper()
 
 	binDir := t.TempDir()
 	stub := filepath.Join(binDir, "azsel")
 	if err := os.WriteFile(stub, []byte("#!/bin/sh\n"+stubBody), 0755); err != nil {
-		t.Fatalf("escribiendo el stub: %v", err)
+		t.Fatalf("writing the stub: %v", err)
 	}
 	if err := os.MkdirAll(filepath.Join(home, ".azsel"), 0755); err != nil {
-		t.Fatalf("preparando el home: %v", err)
+		t.Fatalf("setting up the home: %v", err)
 	}
 
 	cmd := exec.Command(shell, "-c", shellFunc+"\n"+script)
@@ -74,13 +74,13 @@ func runShellFunc(t *testing.T, shell, home, stubBody, script string, extraEnv .
 		"PATH=" + binDir + ":" + os.Getenv("PATH"),
 		"HOME=" + home,
 	}, extraEnv...)
-	// El estado de salida no se comprueba aquí: hay tests que ejercitan
-	// justamente la propagación de códigos distintos de cero.
+	// The exit status is not checked here: some tests exercise precisely
+	// the propagation of non-zero codes.
 	out, _ := cmd.CombinedOutput()
 	return string(out)
 }
 
-// eachShell ejecuta fn una vez por intérprete disponible, como subtest.
+// eachShell runs fn once per available interpreter, as a subtest.
 func eachShell(t *testing.T, fn func(t *testing.T, shell string)) {
 	t.Helper()
 	for _, shell := range shells(t) {
@@ -88,8 +88,8 @@ func eachShell(t *testing.T, fn func(t *testing.T, shell string)) {
 	}
 }
 
-// El caso base: azsel escribe el snippet, la función lo sourcea y la variable
-// queda puesta en el shell.
+// The base case: azsel writes the snippet, the function sources it, and the
+// variable ends up set in the shell.
 func TestShellFuncSourcesSwitchFile(t *testing.T) {
 	eachShell(t, func(t *testing.T, shell string) {
 		home := t.TempDir()
@@ -97,101 +97,101 @@ func TestShellFuncSourcesSwitchFile(t *testing.T) {
 		out := runShellFunc(t, shell, home, stub, `azsel use acme; echo "RESULT=$AZURE_CONFIG_DIR"`)
 
 		if !strings.Contains(out, "RESULT=/fake/tenants/acme") {
-			t.Errorf("la variable no llegó al shell.\nsalida:\n%s", out)
+			t.Errorf("the variable did not reach the shell.\noutput:\n%s", out)
 		}
 	})
 }
 
-// Tras sourcear, el fichero debe desaparecer: si sobreviviera, la siguiente
-// invocación lo volvería a aplicar.
+// After sourcing, the file should disappear: if it survived, the next
+// invocation would apply it again.
 func TestShellFuncRemovesSwitchFileAfterSourcing(t *testing.T) {
 	eachShell(t, func(t *testing.T, shell string) {
 		home := t.TempDir()
 		stub := `printf 'export AZURE_CONFIG_DIR=%s\n' /fake/acme > "$AZSEL_SWITCH_FILE"` + "\n"
 		out := runShellFunc(t, shell, home, stub,
-			`azsel use acme; ls "$HOME/.azsel/" | grep -c switch || echo "SIN_RESTOS"`)
+			`azsel use acme; ls "$HOME/.azsel/" | grep -c switch || echo "NO_LEFTOVERS"`)
 
-		if !strings.Contains(out, "SIN_RESTOS") {
-			t.Errorf("quedaron ficheros de switch.\nsalida:\n%s", out)
+		if !strings.Contains(out, "NO_LEFTOVERS") {
+			t.Errorf("switch files were left behind.\noutput:\n%s", out)
 		}
 	})
 }
 
-// El corazón de #4: cada shell usa su propia ruta, derivada de su PID. Sin
-// esto, una terminal consumía y borraba el switch pendiente de otra.
+// The heart of #4: each shell uses its own path, derived from its PID.
+// Without this, one terminal consumed and deleted another's pending switch.
 func TestShellFuncUsesPerShellSwitchFile(t *testing.T) {
 	eachShell(t, func(t *testing.T, shell string) {
 		home := t.TempDir()
-		// El stub delata la ruta que le han pasado en vez de escribir nada.
-		stub := `echo "PATH_USADO=$AZSEL_SWITCH_FILE"` + "\n"
+		// The stub gives away the path it was passed instead of writing anything.
+		stub := `echo "PATH_USED=$AZSEL_SWITCH_FILE"` + "\n"
 
 		first := runShellFunc(t, shell, home, stub, `azsel list`)
 		second := runShellFunc(t, shell, home, stub, `azsel list`)
 
 		extract := func(out string) string {
 			for _, line := range strings.Split(out, "\n") {
-				if strings.HasPrefix(line, "PATH_USADO=") {
-					return strings.TrimPrefix(line, "PATH_USADO=")
+				if strings.HasPrefix(line, "PATH_USED=") {
+					return strings.TrimPrefix(line, "PATH_USED=")
 				}
 			}
-			t.Fatalf("el stub no reportó ruta.\nsalida:\n%s", out)
+			t.Fatalf("the stub did not report a path.\noutput:\n%s", out)
 			return ""
 		}
 		a, b := extract(first), extract(second)
 
 		if a == b {
-			t.Errorf("dos shells usaron la misma ruta (%s); deben diferir por PID", a)
+			t.Errorf("two shells used the same path (%s); they must differ by PID", a)
 		}
 		for _, got := range []string{a, b} {
 			if !strings.HasPrefix(got, filepath.Join(home, ".azsel", ".switch.")) {
-				t.Errorf("ruta = %q, quería ~/.azsel/.switch.<pid>", got)
+				t.Errorf("path = %q, wanted ~/.azsel/.switch.<pid>", got)
 			}
 		}
 	})
 }
 
-// AZSEL_SWITCH_FILE es para el subproceso, no para la sesión: no debe quedar
-// colgando en el entorno del usuario.
+// AZSEL_SWITCH_FILE is for the subprocess, not for the session: it must not
+// be left dangling in the user's environment.
 func TestShellFuncDoesNotLeakSwitchVar(t *testing.T) {
 	eachShell(t, func(t *testing.T, shell string) {
 		home := t.TempDir()
 		out := runShellFunc(t, shell, home, "true\n",
-			`azsel list; echo "FUGA=[${AZSEL_SWITCH_FILE:-}]"`)
+			`azsel list; echo "LEAK=[${AZSEL_SWITCH_FILE:-}]"`)
 
-		if !strings.Contains(out, "FUGA=[]") {
-			t.Errorf("AZSEL_SWITCH_FILE quedó en el entorno.\nsalida:\n%s", out)
+		if !strings.Contains(out, "LEAK=[]") {
+			t.Errorf("AZSEL_SWITCH_FILE was left in the environment.\noutput:\n%s", out)
 		}
 	})
 }
 
-// La función respeta AZSEL_HOME, igual que el binario.
+// The function respects AZSEL_HOME, just like the binary.
 func TestShellFuncHonoursAzselHome(t *testing.T) {
 	eachShell(t, func(t *testing.T, shell string) {
 		home := t.TempDir()
 		alt := t.TempDir()
-		stub := `echo "PATH_USADO=$AZSEL_SWITCH_FILE"` + "\n"
+		stub := `echo "PATH_USED=$AZSEL_SWITCH_FILE"` + "\n"
 		out := runShellFunc(t, shell, home, stub, `export AZSEL_HOME=`+alt+`; azsel list`)
 
-		if !strings.Contains(out, "PATH_USADO="+filepath.Join(alt, ".switch.")) {
-			t.Errorf("no se respetó AZSEL_HOME.\nsalida:\n%s", out)
+		if !strings.Contains(out, "PATH_USED="+filepath.Join(alt, ".switch.")) {
+			t.Errorf("AZSEL_HOME was not respected.\noutput:\n%s", out)
 		}
 	})
 }
 
-// Sin fichero de switch, la función no debe romper ni ensuciar la salida.
+// Without a switch file, the function must not break or dirty the output.
 func TestShellFuncWithoutSwitchFile(t *testing.T) {
 	eachShell(t, func(t *testing.T, shell string) {
 		home := t.TempDir()
 		out := runShellFunc(t, shell, home, "true\n", `azsel list; echo "OK=$?"`)
 		if !strings.Contains(out, "OK=0") {
-			t.Errorf("la función falló sin fichero de switch.\nsalida:\n%s", out)
+			t.Errorf("the function failed without a switch file.\noutput:\n%s", out)
 		}
 	})
 }
 
-// #3: el modo depuración debe funcionar en los dos shells. La función usaba
-// `whence -p`, un builtin exclusivo de zsh, y en bash imprimía
-// «whence: command not found» dentro de la propia traza de depuración.
+// #3: debug mode must work in both shells. The function used `whence -p`, a
+// zsh-only builtin, and in bash it printed «whence: command not found» inside
+// the debug trace itself.
 func TestShellFuncDebugIsPortable(t *testing.T) {
 	eachShell(t, func(t *testing.T, shell string) {
 		home := t.TempDir()
@@ -200,87 +200,87 @@ func TestShellFuncDebugIsPortable(t *testing.T) {
 
 		for _, bad := range []string{"command not found", "not found", "whence"} {
 			if strings.Contains(out, bad) {
-				t.Errorf("la traza de depuración contiene %q.\nsalida:\n%s", bad, out)
+				t.Errorf("the debug trace contains %q.\noutput:\n%s", bad, out)
 			}
 		}
-		// Y debe seguir siendo útil.
+		// And it must still be useful.
 		for _, want := range []string{"args: use acme", "switch file:", "sourcing"} {
 			if !strings.Contains(out, want) {
-				t.Errorf("la traza no menciona %q.\nsalida:\n%s", want, out)
+				t.Errorf("the trace does not mention %q.\noutput:\n%s", want, out)
 			}
 		}
 	})
 }
 
-// La función generada no debe contener construcciones exclusivas de zsh: se
-// instala también en .bashrc.
+// The generated function must not contain zsh-only constructs: it's also
+// installed in .bashrc.
 func TestShellFuncHasNoZshOnlyBuiltins(t *testing.T) {
 	for _, bad := range []string{"whence", "typeset", "setopt", "print -"} {
 		if strings.Contains(shellFunc, bad) {
-			t.Errorf("la función usa %q, que no existe en bash", bad)
+			t.Errorf("the function uses %q, which doesn't exist in bash", bad)
 		}
 	}
 }
 
-// La línea que init escribe en el rc debe invocar --print; sin él, init
-// modifica el fichero rc en vez de imprimir la función (ver #2).
+// The line init writes into the rc must invoke --print; without it, init
+// modifies the rc file instead of printing the function (see #2).
 func TestInitLineUsesPrint(t *testing.T) {
 	if !strings.Contains(initLine, "--print") {
-		t.Errorf("initLine = %q, quería que usara --print", initLine)
+		t.Errorf("initLine = %q, wanted it to use --print", initLine)
 	}
 }
 
-// La ayuda del comando raíz mostraba `eval "$(azsel init)"`, sin --print. Sin
-// ese flag, init no imprime la función: modifica el fichero rc. Quien pegara
-// esa línea en su .zshrc se quedaba sin integración.
+// The root command's help showed `eval "$(azsel init)"`, without --print.
+// Without that flag, init doesn't print the function: it modifies the rc
+// file. Anyone pasting that line into their .zshrc was left without
+// integration.
 //
-// La ayuda concatena initLine en vez de repetir el texto, así que este test
-// vigila que esa unión no se deshaga.
+// The help concatenates initLine instead of repeating the text, so this test
+// watches that this join doesn't come undone.
 func TestRootHelpUsesInitLine(t *testing.T) {
 	long := rootCmd.Long
 	if !strings.Contains(long, initLine) {
-		t.Errorf("la ayuda del root no contiene %q:\n%s", initLine, long)
+		t.Errorf("the root help does not contain %q:\n%s", initLine, long)
 	}
 	if strings.Contains(long, `eval "$(azsel init)"`) {
-		t.Error("la ayuda del root sigue mostrando 'azsel init' sin --print")
+		t.Error("the root help still shows 'azsel init' without --print")
 	}
 }
 
-// El wrapper hacía source de lo que encontrase en su ruta, aunque la
-// invocación actual no hubiera escrito nada. Los PID se reutilizan, así que
-// un huérfano dejado por un shell muerto acababa aplicándose en un shell
-// posterior que reutilizara ese PID — el mismo fallo que #4 quería evitar,
-// por otra vía.
+// The wrapper sourced whatever it found at its path, even if the current
+// invocation had written nothing. PIDs get reused, so an orphan left by a
+// dead shell ended up being applied in a later shell that reused that PID —
+// the same bug #4 wanted to avoid, by another route.
 func TestShellFuncIgnoresOrphanFromReusedPID(t *testing.T) {
 	eachShell(t, func(t *testing.T, shell string) {
 		home := t.TempDir()
-		// El stub no escribe nada, como haría `azsel list`.
+		// The stub writes nothing, as `azsel list` would.
 		out := runShellFunc(t, shell, home, "true\n",
-			`printf 'export AZURE_CONFIG_DIR=/tenant/OBSOLETO\n' > "$HOME/.azsel/.switch.$$"
+			`printf 'export AZURE_CONFIG_DIR=/tenant/STALE\n' > "$HOME/.azsel/.switch.$$"
 azsel list
 echo "RESULT=[${AZURE_CONFIG_DIR:-}]"`)
 
 		if !strings.Contains(out, "RESULT=[]") {
-			t.Errorf("se aplicó un switch huérfano.\nsalida:\n%s", out)
+			t.Errorf("an orphaned switch was applied.\noutput:\n%s", out)
 		}
 	})
 }
 
-// El wrapper devolvía siempre 0: el `if` final se comía el estado de salida
-// del binario. `azsel use inexistente && deploy` ejecutaba deploy.
+// The wrapper always returned 0: the final `if` swallowed the binary's exit
+// status. `azsel use nonexistent && deploy` ran deploy.
 func TestShellFuncPropagatesExitStatus(t *testing.T) {
 	eachShell(t, func(t *testing.T, shell string) {
 		home := t.TempDir()
 		out := runShellFunc(t, shell, home, "exit 7\n",
-			`azsel use inexistente; echo "STATUS=$?"`)
+			`azsel use nonexistent; echo "STATUS=$?"`)
 
 		if !strings.Contains(out, "STATUS=7") {
-			t.Errorf("no se propagó el código de salida.\nsalida:\n%s", out)
+			t.Errorf("the exit code was not propagated.\noutput:\n%s", out)
 		}
 	})
 }
 
-// Y el caso feliz debe seguir devolviendo 0 aun habiendo sourceado.
+// And the happy path must still return 0 even after having sourced.
 func TestShellFuncReturnsZeroOnSuccess(t *testing.T) {
 	eachShell(t, func(t *testing.T, shell string) {
 		home := t.TempDir()
@@ -288,7 +288,7 @@ func TestShellFuncReturnsZeroOnSuccess(t *testing.T) {
 		out := runShellFunc(t, shell, home, stub, `azsel use acme; echo "STATUS=$?"`)
 
 		if !strings.Contains(out, "STATUS=0") {
-			t.Errorf("un cambio correcto no devolvió 0.\nsalida:\n%s", out)
+			t.Errorf("a correct switch did not return 0.\noutput:\n%s", out)
 		}
 	})
 }

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -18,25 +18,26 @@ func listSandbox(t *testing.T, tenants ...string) string {
 	for _, name := range tenants {
 		dir, _, err := config.EnsureTenantDir(name)
 		if err != nil {
-			t.Fatalf("preparando: %v", err)
+			t.Fatalf("setup: %v", err)
 		}
 		cfg.Tenants = append(cfg.Tenants, config.Tenant{Name: name, TenantID: name + "-id", ConfigDir: dir})
 	}
 	if err := config.Save(cfg); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	return home
 }
 
-// list separa activo de default: el activo sale de AZURE_CONFIG_DIR, el
-// default del enlace. Deben poder ser tenants distintos.
+// list separates active from default: the active one comes from
+// AZURE_CONFIG_DIR, the default from the link. They must be able to be
+// different tenants.
 func TestListShowsActiveAndDefaultSeparately(t *testing.T) {
 	home := listSandbox(t, "contoso", "fabrikam")
 	cfg, _ := config.Load()
 	if _, err := config.SetDefault(cfg, "contoso", "20260220-120000"); err != nil {
 		t.Fatalf("SetDefault: %v", err)
 	}
-	// activo = fabrikam, default = contoso
+	// active = fabrikam, default = contoso
 	t.Setenv("AZURE_CONFIG_DIR", filepath.Join(home, ".azsel", "tenants", "fabrikam"))
 
 	out := quiet(t)
@@ -45,15 +46,15 @@ func TestListShowsActiveAndDefaultSeparately(t *testing.T) {
 	}
 	got := out()
 	if !strings.Contains(got, "DEFAULT") {
-		t.Errorf("falta la columna DEFAULT:\n%s", got)
+		t.Errorf("the DEFAULT column is missing:\n%s", got)
 	}
-	// La línea de contoso lleva D pero no *; la de fabrikam al revés.
+	// contoso's line has D but not *; fabrikam's the other way around.
 	for _, line := range strings.Split(got, "\n") {
 		if strings.Contains(line, "contoso") && !strings.Contains(line, "D") {
-			t.Errorf("contoso debería marcarse como default: %q", line)
+			t.Errorf("contoso should be marked as default: %q", line)
 		}
 		if strings.Contains(line, "fabrikam") && !strings.HasPrefix(strings.TrimSpace(line), "*") {
-			t.Errorf("fabrikam debería marcarse como activo: %q", line)
+			t.Errorf("fabrikam should be marked as active: %q", line)
 		}
 	}
 }
@@ -64,16 +65,16 @@ func TestListWarnsOnBrokenDefault(t *testing.T) {
 	if _, err := config.SetDefault(cfg, "contoso", "20260220-120000"); err != nil {
 		t.Fatalf("SetDefault: %v", err)
 	}
-	// Rompemos el enlace borrando el destino a mano.
+	// We break the link by deleting the target by hand.
 	if err := os.RemoveAll(filepath.Join(home, ".azsel", "tenants", "contoso")); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	out := quiet(t)
 	if err := run(t, newListCmd()); err != nil {
 		t.Fatalf("list: %v", err)
 	}
 	if got := out(); !strings.Contains(got, "broken symlink") {
-		t.Errorf("list no avisó del enlace roto:\n%s", got)
+		t.Errorf("list did not warn about the broken link:\n%s", got)
 	}
 }
 
@@ -85,12 +86,12 @@ func TestListNoDefault(t *testing.T) {
 	}
 	got := out()
 	if !strings.Contains(got, "DEFAULT") {
-		t.Errorf("la cabecera DEFAULT debe estar siempre:\n%s", got)
+		t.Errorf("the DEFAULT header must always be present:\n%s", got)
 	}
-	// Sin default, ninguna línea de tenant lleva la D marcada.
+	// Without a default, no tenant line has the D marked.
 	for _, line := range strings.Split(got, "\n") {
 		if strings.Contains(line, "contoso") && strings.Contains(strings.Fields(line)[0], "D") {
-			t.Errorf("contoso marcado como default sin haberlo fijado: %q", line)
+			t.Errorf("contoso marked as default without it being set: %q", line)
 		}
 	}
 }

--- a/cmd/remove_default_test.go
+++ b/cmd/remove_default_test.go
@@ -18,18 +18,18 @@ func removeSandbox(t *testing.T, tenants ...string) (home string, cfg *config.Co
 	for _, name := range tenants {
 		dir, _, err := config.EnsureTenantDir(name)
 		if err != nil {
-			t.Fatalf("preparando: %v", err)
+			t.Fatalf("setup: %v", err)
 		}
 		cfg.Tenants = append(cfg.Tenants, config.Tenant{Name: name, ConfigDir: dir})
 	}
 	if err := config.Save(cfg); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	return home, cfg
 }
 
-// Borrar el tenant por defecto debe eliminar el enlace ANTES de borrar el
-// directorio; si no, ~/.azure queda colgando y az revienta.
+// Removing the default tenant must clear the link BEFORE deleting the
+// directory; otherwise ~/.azure is left dangling and az blows up.
 func TestRemoveDefaultTenantClearsLink(t *testing.T) {
 	home, cfg := removeSandbox(t, "contoso")
 	if _, err := config.SetDefault(cfg, "contoso", "20260220-120000"); err != nil {
@@ -41,21 +41,21 @@ func TestRemoveDefaultTenantClearsLink(t *testing.T) {
 		t.Fatalf("remove: %v", err)
 	}
 
-	// El enlace no debe quedar, ni colgando ni de ningún tipo.
+	// The link must not remain, neither dangling nor of any kind.
 	if _, err := os.Lstat(filepath.Join(home, ".azure")); !os.IsNotExist(err) {
-		t.Errorf("~/.azure sigue existiendo tras borrar el tenant por defecto (err=%v)", err)
+		t.Errorf("~/.azure still exists after removing the default tenant (err=%v)", err)
 	}
-	// Y el tenant desapareció del config.
+	// And the tenant disappeared from the config.
 	reloaded, err := config.Load()
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
 	if reloaded.FindTenant("contoso") != nil {
-		t.Error("el tenant sigue en config.json")
+		t.Error("the tenant is still in config.json")
 	}
 }
 
-// Borrar un tenant que NO es el default deja el enlace intacto.
+// Removing a tenant that is NOT the default leaves the link intact.
 func TestRemoveNonDefaultTenantLeavesLink(t *testing.T) {
 	home, cfg := removeSandbox(t, "contoso", "fabrikam")
 	if _, err := config.SetDefault(cfg, "contoso", "20260220-120000"); err != nil {
@@ -67,36 +67,36 @@ func TestRemoveNonDefaultTenantLeavesLink(t *testing.T) {
 		t.Fatalf("remove: %v", err)
 	}
 
-	// El enlace a contoso sigue vivo y apuntando bien.
+	// The link to contoso is still alive and pointing correctly.
 	got, err := os.Readlink(filepath.Join(home, ".azure"))
 	if err != nil {
-		t.Fatalf("el enlace del default desapareció: %v", err)
+		t.Fatalf("the default's link disappeared: %v", err)
 	}
 	if want := cfg.FindTenant("contoso").ConfigDir; got != want {
-		t.Errorf("~/.azure -> %q, quería %q", got, want)
+		t.Errorf("~/.azure -> %q, wanted %q", got, want)
 	}
 }
 
-// Bug del review: si el enlace del default ya está roto (el tenant borrado a
-// mano) y luego se hace `azsel remove`, el enlace quedaba colgando porque el
-// guard solo miraba DefaultSet, no DefaultBroken.
+// Bug from the review: if the default's link is already broken (the tenant
+// deleted by hand) and then `azsel remove` is run, the link was left dangling
+// because the guard only looked at DefaultSet, not DefaultBroken.
 func TestRemoveTenantWithAlreadyBrokenDefaultLink(t *testing.T) {
 	home, cfg := removeSandbox(t, "contoso")
 	if _, err := config.SetDefault(cfg, "contoso", "20260220-120000"); err != nil {
 		t.Fatalf("SetDefault: %v", err)
 	}
-	// Rompemos el enlace borrando el directorio del tenant a mano — ahora
-	// ~/.azure es un enlace colgando hacia contoso.
+	// We break the link by deleting the tenant's directory by hand — now
+	// ~/.azure is a dangling link to contoso.
 	if err := os.RemoveAll(filepath.Join(home, ".azsel", "tenants", "contoso")); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	quiet(t)
 
 	if err := run(t, newRemoveCmd(), "contoso", "-f"); err != nil {
 		t.Fatalf("remove: %v", err)
 	}
-	// El enlace roto no debe sobrevivir a la eliminación.
+	// The broken link must not survive the removal.
 	if _, err := os.Lstat(filepath.Join(home, ".azure")); !os.IsNotExist(err) {
-		t.Errorf("~/.azure sigue existiendo (colgando) tras borrar el tenant (err=%v)", err)
+		t.Errorf("~/.azure still exists (dangling) after removing the tenant (err=%v)", err)
 	}
 }

--- a/cmd/shell_detect_test.go
+++ b/cmd/shell_detect_test.go
@@ -12,16 +12,16 @@ func TestDetectShellRC(t *testing.T) {
 		name       string
 		shell      string
 		makeBashrc bool
-		wantRC     string // relativo al home; "" = no soportado
+		wantRC     string // relative to home; "" = unsupported
 		wantShell  string
 	}{
 		{"zsh", "/bin/zsh", false, ".zshrc", "zsh"},
-		{"zsh en otra ruta", "/opt/homebrew/bin/zsh", false, ".zshrc", "zsh"},
-		{"bash con bashrc", "/bin/bash", true, ".bashrc", "bash"},
-		{"bash sin bashrc", "/bin/bash", false, ".bash_profile", "bash"},
+		{"zsh at another path", "/opt/homebrew/bin/zsh", false, ".zshrc", "zsh"},
+		{"bash with bashrc", "/bin/bash", true, ".bashrc", "bash"},
+		{"bash without bashrc", "/bin/bash", false, ".bash_profile", "bash"},
 		{"fish", "/opt/homebrew/bin/fish", false, "", "fish"},
 		{"sh", "/bin/sh", false, "", "sh"},
-		{"SHELL vacío", "", false, "", ""},
+		{"empty SHELL", "", false, "", ""},
 	}
 
 	for _, c := range cases {
@@ -31,7 +31,7 @@ func TestDetectShellRC(t *testing.T) {
 			t.Setenv("SHELL", c.shell)
 			if c.makeBashrc {
 				if err := os.WriteFile(filepath.Join(home, ".bashrc"), nil, 0644); err != nil {
-					t.Fatalf("preparando: %v", err)
+					t.Fatalf("setup: %v", err)
 				}
 			}
 
@@ -44,54 +44,54 @@ func TestDetectShellRC(t *testing.T) {
 				want = filepath.Join(home, c.wantRC)
 			}
 			if rc != want {
-				t.Errorf("rcFile = %q, quería %q", rc, want)
+				t.Errorf("rcFile = %q, wanted %q", rc, want)
 			}
 			if shell != c.wantShell {
-				t.Errorf("shellName = %q, quería %q", shell, c.wantShell)
+				t.Errorf("shellName = %q, wanted %q", shell, c.wantShell)
 			}
 		})
 	}
 }
 
-// El mensaje anterior decía "add this manually to your shell rc", lo cual es
-// falso para fish: la función usa sintaxis bash/zsh que fish no interpreta.
+// The previous message said "add this manually to your shell rc", which is
+// false for fish: the function uses bash/zsh syntax that fish doesn't interpret.
 func TestUnsupportedShellErrorIsHonest(t *testing.T) {
 	got := unsupportedShellError("fish").Error()
 
 	if !strings.Contains(got, "fish") {
-		t.Errorf("el error no nombra el shell detectado:\n%s", got)
+		t.Errorf("the error does not name the detected shell:\n%s", got)
 	}
 	if !strings.Contains(got, "bash and zsh") {
-		t.Errorf("el error no dice qué shells sí están soportados:\n%s", got)
+		t.Errorf("the error does not say which shells are supported:\n%s", got)
 	}
-	// Debe ofrecer la salida que sí funciona en cualquier shell.
+	// It should offer the way out that does work in any shell.
 	if !strings.Contains(got, "azsel use") {
-		t.Errorf("el error no menciona la alternativa vía script:\n%s", got)
+		t.Errorf("the error does not mention the script-based alternative:\n%s", got)
 	}
 }
 
 func TestUnsupportedShellErrorWithoutShellEnv(t *testing.T) {
 	got := unsupportedShellError("").Error()
 	if !strings.Contains(got, "$SHELL") {
-		t.Errorf("sin SHELL definido, el error debería mencionarlo:\n%s", got)
+		t.Errorf("with no SHELL set, the error should mention it:\n%s", got)
 	}
 }
 
-// Un fallo al resolver el home es su propio problema, no un shell no
-// soportado. Antes se reportaba como lo segundo, de modo que a un usuario de
-// zsh se le decía que zsh no está soportado.
+// A failure to resolve the home is its own problem, not an unsupported shell.
+// It used to be reported as the latter, so that a zsh user was told that zsh
+// is not supported.
 func TestDetectShellRCSeparatesHomeFailure(t *testing.T) {
 	t.Setenv("SHELL", "/bin/zsh")
 	t.Setenv("HOME", "")
 
 	rc, shell, err := detectShellRC()
 	if err == nil {
-		t.Fatal("detectShellRC devolvió nil sin HOME")
+		t.Fatal("detectShellRC returned nil with no HOME")
 	}
 	if !strings.Contains(err.Error(), "home directory") {
-		t.Errorf("error = %q, quería que mencionara el home", err)
+		t.Errorf("error = %q, wanted it to mention the home", err)
 	}
 	if rc != "" || shell != "" {
-		t.Errorf("rcFile=%q shellName=%q, quería ambos vacíos ante un error", rc, shell)
+		t.Errorf("rcFile=%q shellName=%q, wanted both empty on an error", rc, shell)
 	}
 }

--- a/cmd/tenant_id_test.go
+++ b/cmd/tenant_id_test.go
@@ -11,25 +11,25 @@ func TestNormalizeTenantIDAccepts(t *testing.T) {
 		want string
 		why  string
 	}{
-		{"11111111-1111-1111-1111-111111111111", "11111111-1111-1111-1111-111111111111", "GUID en minúsculas"},
-		{"AABBCCDD-1122-3344-5566-778899AABBCC", "aabbccdd-1122-3344-5566-778899aabbcc", "GUID en mayúsculas, normalizado"},
-		{"  11111111-1111-1111-1111-111111111111  ", "11111111-1111-1111-1111-111111111111", "espacios alrededor"},
-		{"11111111-1111-1111-1111-111111111111\n", "11111111-1111-1111-1111-111111111111", "salto de línea del prompt"},
+		{"11111111-1111-1111-1111-111111111111", "11111111-1111-1111-1111-111111111111", "lowercase GUID"},
+		{"AABBCCDD-1122-3344-5566-778899AABBCC", "aabbccdd-1122-3344-5566-778899aabbcc", "uppercase GUID, normalized"},
+		{"  11111111-1111-1111-1111-111111111111  ", "11111111-1111-1111-1111-111111111111", "surrounding spaces"},
+		{"11111111-1111-1111-1111-111111111111\n", "11111111-1111-1111-1111-111111111111", "trailing newline from the prompt"},
 
-		// az login --tenant también acepta un dominio verificado del tenant.
-		{"contoso.onmicrosoft.com", "contoso.onmicrosoft.com", "dominio onmicrosoft"},
-		{"CONTOSO.ONMICROSOFT.COM", "contoso.onmicrosoft.com", "dominio en mayúsculas"},
-		{"contoso.com", "contoso.com", "dominio propio"},
-		{"my-tenant.example.co.uk", "my-tenant.example.co.uk", "guiones y varios niveles"},
+		// az login --tenant also accepts a verified tenant domain.
+		{"contoso.onmicrosoft.com", "contoso.onmicrosoft.com", "onmicrosoft domain"},
+		{"CONTOSO.ONMICROSOFT.COM", "contoso.onmicrosoft.com", "uppercase domain"},
+		{"contoso.com", "contoso.com", "custom domain"},
+		{"my-tenant.example.co.uk", "my-tenant.example.co.uk", "hyphens and multiple levels"},
 	}
 	for _, c := range cases {
 		got, err := normalizeTenantID(c.in)
 		if err != nil {
-			t.Errorf("normalizeTenantID(%q) = error %v, quería aceptarlo (%s)", c.in, err, c.why)
+			t.Errorf("normalizeTenantID(%q) = error %v, wanted it accepted (%s)", c.in, err, c.why)
 			continue
 		}
 		if got != c.want {
-			t.Errorf("normalizeTenantID(%q) = %q, quería %q (%s)", c.in, got, c.want, c.why)
+			t.Errorf("normalizeTenantID(%q) = %q, wanted %q (%s)", c.in, got, c.want, c.why)
 		}
 	}
 }
@@ -39,40 +39,40 @@ func TestNormalizeTenantIDRejects(t *testing.T) {
 		in  string
 		why string
 	}{
-		{"", "vacío"},
-		{"   ", "solo espacios"},
-		{"contoso", "nombre suelto, sin punto ni forma de GUID"},
-		{"11111111-1111-1111-1111-11111111111", "GUID con un dígito de menos"},
-		{"11111111-1111-1111-1111-1111111111111", "GUID con un dígito de más"},
-		{"11111111-1111-1111-111111111111111", "faltan guiones"},
-		{"gggggggg-1111-1111-1111-111111111111", "caracteres fuera de hexadecimal"},
-		{"11111111 1111 1111 1111 111111111111", "espacios en vez de guiones"},
-		{"-contoso.com", "etiqueta que empieza por guión"},
-		{"contoso-.com", "etiqueta que acaba en guión"},
-		{"contoso..com", "etiqueta vacía"},
-		{"contoso.com.", "punto final"},
-		{".contoso.com", "punto inicial"},
-		{"https://contoso.onmicrosoft.com", "una URL, no un dominio"},
-		{"contoso onmicrosoft com", "espacios"},
+		{"", "empty"},
+		{"   ", "only spaces"},
+		{"contoso", "bare name, no dot and not GUID-shaped"},
+		{"11111111-1111-1111-1111-11111111111", "GUID one digit short"},
+		{"11111111-1111-1111-1111-1111111111111", "GUID one digit too many"},
+		{"11111111-1111-1111-111111111111111", "missing hyphens"},
+		{"gggggggg-1111-1111-1111-111111111111", "non-hexadecimal characters"},
+		{"11111111 1111 1111 1111 111111111111", "spaces instead of hyphens"},
+		{"-contoso.com", "label starting with a hyphen"},
+		{"contoso-.com", "label ending in a hyphen"},
+		{"contoso..com", "empty label"},
+		{"contoso.com.", "trailing dot"},
+		{".contoso.com", "leading dot"},
+		{"https://contoso.onmicrosoft.com", "a URL, not a domain"},
+		{"contoso onmicrosoft com", "spaces"},
 	}
 	for _, c := range cases {
 		if got, err := normalizeTenantID(c.in); err == nil {
-			t.Errorf("normalizeTenantID(%q) = %q, quería rechazarlo (%s)", c.in, got, c.why)
+			t.Errorf("normalizeTenantID(%q) = %q, wanted it rejected (%s)", c.in, got, c.why)
 		}
 	}
 }
 
-// El mensaje tiene que decir qué se esperaba, no solo que está mal: el usuario
-// acaba de pegar algo y necesita saber qué formato quiere azsel.
+// The message has to say what was expected, not just that it's wrong: the user
+// has just pasted something and needs to know what format azsel wants.
 func TestNormalizeTenantIDErrorNamesBothFormats(t *testing.T) {
-	_, err := normalizeTenantID("no-soy-un-tenant")
+	_, err := normalizeTenantID("not-a-tenant")
 	if err == nil {
-		t.Fatal("se aceptó un tenant ID inválido")
+		t.Fatal("an invalid tenant ID was accepted")
 	}
 	got := err.Error()
-	for _, want := range []string{"no-soy-un-tenant", "GUID", "domain"} {
+	for _, want := range []string{"not-a-tenant", "GUID", "domain"} {
 		if !strings.Contains(got, want) {
-			t.Errorf("error = %q, quería que mencionara %q", got, want)
+			t.Errorf("error = %q, wanted it to mention %q", got, want)
 		}
 	}
 }

--- a/internal/azure/azure_test.go
+++ b/internal/azure/azure_test.go
@@ -59,7 +59,7 @@ func TestLoginArguments(t *testing.T) {
 		deviceCode bool
 		want       []string
 	}{
-		{"navegador", false, []string{"az", "login", "--tenant", "TID"}},
+		{"browser", false, []string{"az", "login", "--tenant", "TID"}},
 		{"device code", true, []string{"az", "login", "--tenant", "TID", "--use-device-code"}},
 	}
 	for _, c := range cases {
@@ -69,13 +69,13 @@ func TestLoginArguments(t *testing.T) {
 				t.Fatalf("Login: %v", err)
 			}
 			if !slices.Equal(got.cmd.Args, c.want) {
-				t.Errorf("args = %v, quería %v", got.cmd.Args, c.want)
+				t.Errorf("args = %v, wanted %v", got.cmd.Args, c.want)
 			}
 		})
 	}
 }
 
-// El aislamiento entre tenants depende enteramente de estas dos variables.
+// Isolation between tenants rests entirely on these two variables.
 func TestLoginScopesTheEnvironment(t *testing.T) {
 	// One snapshot of the environment, taken here, is the baseline for both
 	// what command() inherits and what the test measures — reading
@@ -88,7 +88,7 @@ func TestLoginScopesTheEnvironment(t *testing.T) {
 	}
 
 	if v, ok := envValue(got.cmd, "AZURE_CONFIG_DIR"); !ok || v != "/cfg/acme" {
-		t.Errorf("AZURE_CONFIG_DIR = %q (presente=%v), quería «/cfg/acme»", v, ok)
+		t.Errorf("AZURE_CONFIG_DIR = %q (present=%v), wanted /cfg/acme", v, ok)
 	}
 
 	// azsel must add exactly one variable to the inherited environment:
@@ -105,61 +105,61 @@ func TestLoginScopesTheEnvironment(t *testing.T) {
 
 	// The rest of the environment is inherited: az needs proxy, locale, HOME…
 	if _, ok := envValue(got.cmd, "PATH"); !ok {
-		t.Error("no se heredó el entorno del proceso")
+		t.Error("the process environment was not inherited")
 	}
 }
 
-// Dos comportamientos deliberados y fáciles de romper sin querer: el login es
-// interactivo, así que stdin debe llegar a az; y la salida de az va a stderr
-// porque azsel mantiene stdout limpio para el shell.
+// Two deliberate behaviors, easy to break by accident: login is interactive,
+// so stdin must reach az; and az's output goes to stderr because azsel keeps
+// stdout clean for the shell.
 func TestLoginWiresStreams(t *testing.T) {
 	got := stubRun(t, nil)
 	if err := Login("TID", "/cfg", false); err != nil {
 		t.Fatalf("Login: %v", err)
 	}
 	if got.cmd.Stdin != os.Stdin {
-		t.Error("stdin no está conectado: el login interactivo no funcionaría")
+		t.Error("stdin is not connected: interactive login would not work")
 	}
 	if got.cmd.Stdout != os.Stderr {
-		t.Error("stdout de az no va a stderr: ensuciaría la salida estándar")
+		t.Error("az's stdout does not go to stderr: it would pollute standard output")
 	}
 	if got.cmd.Stderr != os.Stderr {
-		t.Error("stderr de az no va a stderr")
+		t.Error("az's stderr does not go to stderr")
 	}
 }
 
 func TestLoginPropagatesFailure(t *testing.T) {
-	want := errors.New("el usuario canceló")
+	want := errors.New("the user cancelled")
 	stubRun(t, func(*exec.Cmd) error { return want })
 
 	err := Login("TID", "/cfg", false)
 	if !errors.Is(err, want) {
-		t.Errorf("error = %v, quería %v", err, want)
+		t.Errorf("error = %v, wanted %v", err, want)
 	}
 }
 
 func TestAvailable(t *testing.T) {
-	t.Run("az presente", func(t *testing.T) {
+	t.Run("az present", func(t *testing.T) {
 		stubLookPath(t, func(string) (string, error) { return "/usr/local/bin/az", nil })
 		if err := Available(); err != nil {
 			t.Errorf("Available: %v", err)
 		}
 	})
 
-	t.Run("az ausente", func(t *testing.T) {
+	t.Run("az absent", func(t *testing.T) {
 		stubLookPath(t, func(name string) (string, error) {
 			return "", fmt.Errorf("exec: %q: executable file not found in $PATH", name)
 		})
 		err := Available()
 		if err == nil {
-			t.Fatal("Available devolvió nil sin az en el PATH")
+			t.Fatal("Available returned nil with az absent from PATH")
 		}
 		if !strings.Contains(err.Error(), "Azure CLI") {
-			t.Errorf("error = %q, quería que nombrara Azure CLI", err)
+			t.Errorf("error = %q, wanted it to name Azure CLI", err)
 		}
 	})
 
-	t.Run("se consulta el binario correcto", func(t *testing.T) {
+	t.Run("the correct binary is queried", func(t *testing.T) {
 		var asked string
 		stubLookPath(t, func(name string) (string, error) {
 			asked = name
@@ -169,7 +169,7 @@ func TestAvailable(t *testing.T) {
 			t.Fatalf("Available: %v", err)
 		}
 		if asked != "az" {
-			t.Errorf("se buscó %q, quería «az»", asked)
+			t.Errorf("looked up %q, wanted az", asked)
 		}
 	})
 }
@@ -187,7 +187,7 @@ func TestCommandEnvOverridesInheritedValues(t *testing.T) {
 	}
 
 	if v, _ := envValue(got.cmd, "AZURE_CONFIG_DIR"); v != "/cfg/acme" {
-		t.Errorf("AZURE_CONFIG_DIR efectivo = %q, quería «/cfg/acme»", v)
+		t.Errorf("effective AZURE_CONFIG_DIR = %q, wanted /cfg/acme", v)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -28,13 +28,13 @@ func TestBaseDirHonoursEnvHome(t *testing.T) {
 		t.Fatalf("BaseDir: %v", err)
 	}
 	if got != dir {
-		t.Errorf("BaseDir = %q, quería %q", got, dir)
+		t.Errorf("BaseDir = %q, wanted %q", got, dir)
 	}
 }
 
 func TestBaseDirFallsBackToHome(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("azsel solo se publica para linux y darwin")
+		t.Skip("azsel is only published for linux and darwin")
 	}
 	home := t.TempDir()
 	t.Setenv(config.EnvHome, "")
@@ -45,16 +45,16 @@ func TestBaseDirFallsBackToHome(t *testing.T) {
 		t.Fatalf("BaseDir: %v", err)
 	}
 	if want := filepath.Join(home, ".azsel"); got != want {
-		t.Errorf("BaseDir = %q, quería %q", got, want)
+		t.Errorf("BaseDir = %q, wanted %q", got, want)
 	}
 }
 
-// Preguntar por una ruta no debe tener efectos en el disco. Antes sí los
-// tenía: cada función de ruta hacía MkdirAll.
+// Asking for a path must have no effect on disk. It used to: every path
+// function called MkdirAll.
 func TestPathFunctionsCreateNothing(t *testing.T) {
 	dir := sandbox(t)
 	if err := os.RemoveAll(dir); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 
 	for _, fn := range []struct {
@@ -72,7 +72,7 @@ func TestPathFunctionsCreateNothing(t *testing.T) {
 			t.Fatalf("%s: %v", fn.name, err)
 		}
 		if _, err := os.Stat(dir); !os.IsNotExist(err) {
-			t.Fatalf("%s creó %s", fn.name, dir)
+			t.Fatalf("%s created %s", fn.name, dir)
 		}
 	}
 }
@@ -97,7 +97,7 @@ func TestPathsHangOffBaseDir(t *testing.T) {
 			t.Fatalf("%s: %v", c.name, err)
 		}
 		if got != c.want {
-			t.Errorf("%s = %q, quería %q", c.name, got, c.want)
+			t.Errorf("%s = %q, wanted %q", c.name, got, c.want)
 		}
 	}
 }
@@ -105,18 +105,18 @@ func TestPathsHangOffBaseDir(t *testing.T) {
 func TestEnsureBaseDirCreates(t *testing.T) {
 	dir := sandbox(t)
 	if err := os.RemoveAll(dir); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	if _, err := config.EnsureBaseDir(); err != nil {
 		t.Fatalf("EnsureBaseDir: %v", err)
 	}
 	if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
-		t.Fatalf("no se creó %s: %v", dir, err)
+		t.Fatalf("%s was not created: %v", dir, err)
 	}
 }
 
-// El bool 'created' es lo que permitirá a #9 revertir un login fallido sin
-// borrar un directorio preexistente con credenciales válidas.
+// The 'created' bool is what will let #9 revert a failed login without
+// deleting a preexisting directory with valid credentials.
 func TestEnsureTenantDirReportsWhoCreatedIt(t *testing.T) {
 	sandbox(t)
 
@@ -125,18 +125,18 @@ func TestEnsureTenantDirReportsWhoCreatedIt(t *testing.T) {
 		t.Fatalf("EnsureTenantDir: %v", err)
 	}
 	if !created {
-		t.Error("created = false en la primera llamada, quería true")
+		t.Error("created = false on the first call, wanted true")
 	}
 	if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
-		t.Fatalf("no se creó %s: %v", dir, err)
+		t.Fatalf("%s was not created: %v", dir, err)
 	}
 
 	_, created, err = config.EnsureTenantDir("acme")
 	if err != nil {
-		t.Fatalf("EnsureTenantDir (segunda): %v", err)
+		t.Fatalf("EnsureTenantDir (second): %v", err)
 	}
 	if created {
-		t.Error("created = true sobre un directorio preexistente, quería false")
+		t.Error("created = true on a preexisting directory, wanted false")
 	}
 }
 
@@ -147,10 +147,10 @@ func TestEnsureExtensionsDirCreates(t *testing.T) {
 		t.Fatalf("EnsureExtensionsDir: %v", err)
 	}
 	if want := filepath.Join(dir, "extensions"); got != want {
-		t.Errorf("= %q, quería %q", got, want)
+		t.Errorf("= %q, wanted %q", got, want)
 	}
 	if fi, err := os.Stat(got); err != nil || !fi.IsDir() {
-		t.Fatalf("no se creó %s: %v", got, err)
+		t.Fatalf("%s was not created: %v", got, err)
 	}
 }
 
@@ -158,24 +158,24 @@ func TestLoadMissingFileReturnsEmptyConfig(t *testing.T) {
 	sandbox(t)
 	cfg, err := config.Load()
 	if err != nil {
-		t.Fatalf("Load sobre fichero inexistente devolvió error: %v", err)
+		t.Fatalf("Load on a nonexistent file returned an error: %v", err)
 	}
 	if len(cfg.Tenants) != 0 {
-		t.Errorf("Tenants = %v, quería vacío", cfg.Tenants)
+		t.Errorf("Tenants = %v, wanted empty", cfg.Tenants)
 	}
 }
 
 func TestLoadCorruptJSON(t *testing.T) {
 	dir := sandbox(t)
 	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte("{no json"), 0644); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	_, err := config.Load()
 	if err == nil {
-		t.Fatal("Load devolvió nil sobre JSON corrupto")
+		t.Fatal("Load returned nil on corrupt JSON")
 	}
 	if !strings.Contains(err.Error(), "parsing config") {
-		t.Errorf("error = %q, quería que mencionara «parsing config»", err)
+		t.Errorf("error = %q, wanted it to mention 'parsing config'", err)
 	}
 }
 
@@ -193,27 +193,27 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 		t.Fatalf("Load: %v", err)
 	}
 	if len(got.Tenants) != len(want.Tenants) {
-		t.Fatalf("%d tenants, quería %d", len(got.Tenants), len(want.Tenants))
+		t.Fatalf("%d tenants, wanted %d", len(got.Tenants), len(want.Tenants))
 	}
 	for i := range want.Tenants {
 		if got.Tenants[i] != want.Tenants[i] {
-			t.Errorf("tenant %d = %+v, quería %+v", i, got.Tenants[i], want.Tenants[i])
+			t.Errorf("tenant %d = %+v, wanted %+v", i, got.Tenants[i], want.Tenants[i])
 		}
 	}
 }
 
-// Save debe crear el directorio base si no existe: es el primer contacto
-// con el disco en una instalación nueva.
+// Save must create the base directory if it does not exist: it is the first
+// contact with disk on a fresh install.
 func TestSaveCreatesBaseDir(t *testing.T) {
 	dir := sandbox(t)
 	if err := os.RemoveAll(dir); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	if err := config.Save(&config.Config{}); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(dir, "config.json")); err != nil {
-		t.Fatalf("no se escribió config.json: %v", err)
+		t.Fatalf("config.json was not written: %v", err)
 	}
 }
 
@@ -221,21 +221,21 @@ func TestFindTenantIsCaseInsensitive(t *testing.T) {
 	cfg := &config.Config{Tenants: []config.Tenant{{Name: "acme"}}}
 	for _, q := range []string{"acme", "ACME", "AcMe"} {
 		if got := cfg.FindTenant(q); got == nil {
-			t.Errorf("FindTenant(%q) = nil, quería el tenant", q)
+			t.Errorf("FindTenant(%q) = nil, wanted the tenant", q)
 		}
 	}
 	if got := cfg.FindTenant("globex"); got != nil {
-		t.Errorf("FindTenant(\"globex\") = %+v, quería nil", got)
+		t.Errorf("FindTenant(\"globex\") = %+v, wanted nil", got)
 	}
 }
 
-// FindTenant devuelve un puntero al elemento del slice, no una copia: quien
-// lo recibe puede mutar la configuración.
+// FindTenant returns a pointer into the slice, not a copy: the caller can
+// mutate the config.
 func TestFindTenantReturnsPointerIntoSlice(t *testing.T) {
 	cfg := &config.Config{Tenants: []config.Tenant{{Name: "acme", TenantID: "old"}}}
 	cfg.FindTenant("acme").TenantID = "new"
 	if cfg.Tenants[0].TenantID != "new" {
-		t.Errorf("TenantID = %q, quería «new»", cfg.Tenants[0].TenantID)
+		t.Errorf("TenantID = %q, wanted 'new'", cfg.Tenants[0].TenantID)
 	}
 }
 
@@ -245,12 +245,12 @@ func TestAddTenantRejectsDuplicates(t *testing.T) {
 	if err := cfg.AddTenant(config.Tenant{Name: "acme"}); err != nil {
 		t.Fatalf("AddTenant: %v", err)
 	}
-	// El duplicado se detecta sin distinguir mayúsculas, igual que FindTenant.
+	// The duplicate is detected case-insensitively, just like FindTenant.
 	if err := cfg.AddTenant(config.Tenant{Name: "ACME"}); err == nil {
-		t.Fatal("AddTenant aceptó un duplicado")
+		t.Fatal("AddTenant accepted a duplicate")
 	}
 	if len(cfg.Tenants) != 1 {
-		t.Errorf("%d tenants, quería 1", len(cfg.Tenants))
+		t.Errorf("%d tenants, wanted 1", len(cfg.Tenants))
 	}
 }
 
@@ -265,7 +265,7 @@ func TestAddTenantPersists(t *testing.T) {
 		t.Fatalf("Load: %v", err)
 	}
 	if reloaded.FindTenant("acme") == nil {
-		t.Error("el tenant no se persistió")
+		t.Error("the tenant was not persisted")
 	}
 }
 
@@ -277,17 +277,17 @@ func TestRemoveTenant(t *testing.T) {
 		t.Fatalf("RemoveTenant: %v", err)
 	}
 	if cfg.FindTenant("acme") != nil {
-		t.Error("acme sigue presente")
+		t.Error("acme is still present")
 	}
 	if cfg.FindTenant("globex") == nil {
-		t.Error("RemoveTenant se llevó por delante a globex")
+		t.Error("RemoveTenant took globex down with it")
 	}
 
 	if err := cfg.RemoveTenant("globex"); err != nil {
 		t.Fatalf("RemoveTenant: %v", err)
 	}
 	if len(cfg.Tenants) != 0 {
-		t.Errorf("%d tenants, quería 0", len(cfg.Tenants))
+		t.Errorf("%d tenants, wanted 0", len(cfg.Tenants))
 	}
 
 	reloaded, err := config.Load()
@@ -295,15 +295,15 @@ func TestRemoveTenant(t *testing.T) {
 		t.Fatalf("Load: %v", err)
 	}
 	if len(reloaded.Tenants) != 0 {
-		t.Errorf("en disco quedan %d tenants, quería 0", len(reloaded.Tenants))
+		t.Errorf("%d tenants left on disk, wanted 0", len(reloaded.Tenants))
 	}
 }
 
 func TestRemoveTenantNotFound(t *testing.T) {
 	sandbox(t)
 	cfg := &config.Config{}
-	if err := cfg.RemoveTenant("fantasma"); err == nil {
-		t.Fatal("RemoveTenant devolvió nil sobre un tenant inexistente")
+	if err := cfg.RemoveTenant("ghost"); err == nil {
+		t.Fatal("RemoveTenant returned nil on a nonexistent tenant")
 	}
 }
 
@@ -317,38 +317,38 @@ func TestWriteEnv(t *testing.T) {
 	path := filepath.Join(dir, ".switch")
 	data, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatalf("leyendo .switch: %v", err)
+		t.Fatalf("reading .switch: %v", err)
 	}
 	if string(data) != lines {
-		t.Errorf("contenido = %q, quería %q", data, lines)
+		t.Errorf("content = %q, wanted %q", data, lines)
 	}
 
 	fi, err := os.Stat(path)
 	if err != nil {
 		t.Fatalf("stat: %v", err)
 	}
-	// 0600 desde #4: el shell hace source de este fichero, así que su
-	// contenido se ejecuta con los permisos del usuario.
+	// 0600 since #4: the shell sources this file, so its contents run with the
+	// user's permissions.
 	if perm := fi.Mode().Perm(); perm != 0600 {
-		t.Errorf("permisos = %04o, quería 0600", perm)
+		t.Errorf("perms = %04o, wanted 0600", perm)
 	}
 }
 
 func TestWriteEnvCreatesBaseDir(t *testing.T) {
 	dir := sandbox(t)
 	if err := os.RemoveAll(dir); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	if err := config.WriteEnv("export FOO=bar\n"); err != nil {
 		t.Fatalf("WriteEnv: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(dir, ".switch")); err != nil {
-		t.Fatalf("no se escribió .switch: %v", err)
+		t.Fatalf(".switch was not written: %v", err)
 	}
 }
 
-// El formato en disco es API: la función de shell y cualquier edición manual
-// dependen de estas claves.
+// The on-disk format is API: the shell function and any manual editing depend
+// on these keys.
 func TestConfigJSONShape(t *testing.T) {
 	sandbox(t)
 	if err := config.Save(&config.Config{Tenants: []config.Tenant{
@@ -359,7 +359,7 @@ func TestConfigJSONShape(t *testing.T) {
 	path, _ := config.ConfigPath()
 	data, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatalf("leyendo: %v", err)
+		t.Fatalf("reading: %v", err)
 	}
 	var raw map[string]any
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -367,12 +367,12 @@ func TestConfigJSONShape(t *testing.T) {
 	}
 	tenants, ok := raw["tenants"].([]any)
 	if !ok || len(tenants) != 1 {
-		t.Fatalf("clave «tenants» = %v", raw["tenants"])
+		t.Fatalf("'tenants' key = %v", raw["tenants"])
 	}
 	first := tenants[0].(map[string]any)
 	for _, key := range []string{"name", "tenantId", "configDir"} {
 		if _, ok := first[key]; !ok {
-			t.Errorf("falta la clave %q en el JSON", key)
+			t.Errorf("missing key %q in the JSON", key)
 		}
 	}
 }

--- a/internal/config/default_integration_test.go
+++ b/internal/config/default_integration_test.go
@@ -71,7 +71,7 @@ func TestIntegrationAzFollowsDefaultLink(t *testing.T) {
 
 	tenant := cfg.FindTenant("contoso").ConfigDir
 	if !wrote(tenant) {
-		t.Error("az no escribió en el tenant por defecto vía el enlace")
+		t.Error("az did not write to the default tenant via the link")
 	}
 }
 
@@ -87,10 +87,10 @@ func TestIntegrationConfigDirOverridesLink(t *testing.T) {
 	azConfigSet(t, az, home, other)
 
 	if !wrote(other) {
-		t.Error("az no respetó AZURE_CONFIG_DIR")
+		t.Error("az did not honor AZURE_CONFIG_DIR")
 	}
 	if wrote(cfg.FindTenant("contoso").ConfigDir) {
-		t.Error("az escribió en el default pese a AZURE_CONFIG_DIR; la variable debe ganar")
+		t.Error("az wrote to the default despite AZURE_CONFIG_DIR; the variable must win")
 	}
 }
 
@@ -100,10 +100,10 @@ func TestIntegrationNoDefaultUsesNativeAzure(t *testing.T) {
 	home, _ := azureSandbox(t)
 	azure := filepath.Join(home, ".azure")
 	if err := os.MkdirAll(azure, 0755); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	azConfigSet(t, az, home, "")
 	if !wrote(azure) {
-		t.Error("az no usó su ~/.azure nativo sin default")
+		t.Error("az did not use its native ~/.azure with no default")
 	}
 }

--- a/internal/config/default_test.go
+++ b/internal/config/default_test.go
@@ -22,7 +22,7 @@ func azureSandbox(t *testing.T, tenants ...string) (home string, cfg *config.Con
 	for _, name := range tenants {
 		dir, _, err := config.EnsureTenantDir(name)
 		if err != nil {
-			t.Fatalf("preparando tenant %q: %v", name, err)
+			t.Fatalf("setup tenant %q: %v", name, err)
 		}
 		cfg.Tenants = append(cfg.Tenants, config.Tenant{Name: name, ConfigDir: dir})
 	}
@@ -41,25 +41,25 @@ func TestResolveDefaultNone(t *testing.T) {
 		t.Fatalf("ResolveDefault: %v", err)
 	}
 	if info.State != config.DefaultNone {
-		t.Errorf("State = %v, quería DefaultNone", info.State)
+		t.Errorf("State = %v, wanted DefaultNone", info.State)
 	}
 	if info.Tenant != "" {
-		t.Errorf("Tenant = %q, quería vacío", info.Tenant)
+		t.Errorf("Tenant = %q, wanted empty", info.Tenant)
 	}
 }
 
 func TestResolveDefaultNative(t *testing.T) {
 	home, cfg := azureSandbox(t)
-	// ~/.azure es un directorio real: el perfil nativo de az.
+	// ~/.azure is a real directory: az's native profile.
 	if err := os.MkdirAll(azurePath(t, home), 0755); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	info, err := config.ResolveDefault(cfg)
 	if err != nil {
 		t.Fatalf("ResolveDefault: %v", err)
 	}
 	if info.State != config.DefaultNative {
-		t.Errorf("State = %v, quería DefaultNative", info.State)
+		t.Errorf("State = %v, wanted DefaultNative", info.State)
 	}
 }
 
@@ -67,152 +67,153 @@ func TestResolveDefaultSet(t *testing.T) {
 	home, cfg := azureSandbox(t, "contoso")
 	target := cfg.FindTenant("contoso").ConfigDir
 	if err := os.Symlink(target, azurePath(t, home)); err != nil {
-		t.Fatalf("preparando enlace: %v", err)
+		t.Fatalf("setup link: %v", err)
 	}
 	info, err := config.ResolveDefault(cfg)
 	if err != nil {
 		t.Fatalf("ResolveDefault: %v", err)
 	}
 	if info.State != config.DefaultSet {
-		t.Fatalf("State = %v, quería DefaultSet", info.State)
+		t.Fatalf("State = %v, wanted DefaultSet", info.State)
 	}
 	if info.Tenant != "contoso" {
-		t.Errorf("Tenant = %q, quería «contoso»", info.Tenant)
+		t.Errorf("Tenant = %q, wanted 'contoso'", info.Tenant)
 	}
 	if info.Target != target {
-		t.Errorf("Target = %q, quería %q", info.Target, target)
+		t.Errorf("Target = %q, wanted %q", info.Target, target)
 	}
 }
 
-// Enlace a un directorio dentro de ~/.azsel/tenants pero de un tenant que no
-// está en config.json: no es un default de azsel.
+// Link to a directory inside ~/.azsel/tenants but of a tenant not in
+// config.json: it is not an azsel default.
 func TestResolveDefaultUnknownTenant(t *testing.T) {
 	home, cfg := azureSandbox(t, "contoso")
-	// Creamos el directorio de 'fabrikam' pero NO lo añadimos al config.
+	// We create 'fabrikam's directory but do NOT add it to the config.
 	ghost, _, err := config.EnsureTenantDir("fabrikam")
 	if err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	if err := os.Symlink(ghost, azurePath(t, home)); err != nil {
-		t.Fatalf("preparando enlace: %v", err)
+		t.Fatalf("setup link: %v", err)
 	}
 	info, err := config.ResolveDefault(cfg)
 	if err != nil {
 		t.Fatalf("ResolveDefault: %v", err)
 	}
 	if info.State != config.DefaultForeign {
-		t.Errorf("State = %v, quería DefaultForeign (tenant desconocido)", info.State)
+		t.Errorf("State = %v, wanted DefaultForeign (unknown tenant)", info.State)
 	}
 }
 
-// Enlace a algo completamente fuera de ~/.azsel.
+// Link to something completely outside ~/.azsel.
 func TestResolveDefaultForeign(t *testing.T) {
 	home, cfg := azureSandbox(t)
 	outside := t.TempDir()
 	if err := os.Symlink(outside, azurePath(t, home)); err != nil {
-		t.Fatalf("preparando enlace: %v", err)
+		t.Fatalf("setup link: %v", err)
 	}
 	info, err := config.ResolveDefault(cfg)
 	if err != nil {
 		t.Fatalf("ResolveDefault: %v", err)
 	}
 	if info.State != config.DefaultForeign {
-		t.Errorf("State = %v, quería DefaultForeign", info.State)
+		t.Errorf("State = %v, wanted DefaultForeign", info.State)
 	}
 	if info.Target != outside {
-		t.Errorf("Target = %q, quería %q", info.Target, outside)
+		t.Errorf("Target = %q, wanted %q", info.Target, outside)
 	}
 }
 
-// El caso peligroso: enlace cuyo destino ya no existe. az revienta con esto,
-// así que hay que distinguirlo.
+// The dangerous case: a link whose target no longer exists. az blows up on
+// this, so it must be distinguished.
 func TestResolveDefaultBroken(t *testing.T) {
 	home, cfg := azureSandbox(t, "contoso")
 	target := cfg.FindTenant("contoso").ConfigDir
 	if err := os.Symlink(target, azurePath(t, home)); err != nil {
-		t.Fatalf("preparando enlace: %v", err)
+		t.Fatalf("setup link: %v", err)
 	}
-	// Borramos el destino: el enlace queda colgando.
+	// Delete the target: the link dangles.
 	if err := os.RemoveAll(target); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	info, err := config.ResolveDefault(cfg)
 	if err != nil {
 		t.Fatalf("ResolveDefault: %v", err)
 	}
 	if info.State != config.DefaultBroken {
-		t.Errorf("State = %v, quería DefaultBroken", info.State)
+		t.Errorf("State = %v, wanted DefaultBroken", info.State)
 	}
 	if info.Target != target {
-		t.Errorf("Target = %q, quería %q para poder diagnosticar", info.Target, target)
+		t.Errorf("Target = %q, wanted %q to be able to diagnose", info.Target, target)
 	}
 }
 
-// Un enlace escrito con ruta relativa debe resolverse igual que uno absoluto.
+// A link written with a relative path must resolve the same as an absolute
+// one.
 func TestResolveDefaultRelativeSymlink(t *testing.T) {
 	home, cfg := azureSandbox(t, "contoso")
 	target := cfg.FindTenant("contoso").ConfigDir
 	rel, err := filepath.Rel(home, target)
 	if err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
-	// Enlace relativo desde ~/ hacia .azsel/tenants/contoso
+	// Relative link from ~/ to .azsel/tenants/contoso
 	if err := os.Symlink(rel, azurePath(t, home)); err != nil {
-		t.Fatalf("preparando enlace relativo: %v", err)
+		t.Fatalf("setup relative link: %v", err)
 	}
 	info, err := config.ResolveDefault(cfg)
 	if err != nil {
 		t.Fatalf("ResolveDefault: %v", err)
 	}
 	if info.State != config.DefaultSet || info.Tenant != "contoso" {
-		t.Errorf("State=%v Tenant=%q, quería DefaultSet/contoso", info.State, info.Tenant)
+		t.Errorf("State=%v Tenant=%q, wanted DefaultSet/contoso", info.State, info.Tenant)
 	}
 }
 
-// Un enlace que apunta MÁS ADENTRO de un tenant (no al directorio del tenant)
-// no debe contar como default de azsel.
+// A link pointing DEEPER INTO a tenant (not at the tenant's directory) must
+// not count as an azsel default.
 func TestResolveDefaultLinkDeeperThanTenant(t *testing.T) {
 	home, cfg := azureSandbox(t, "contoso")
 	sub := filepath.Join(cfg.FindTenant("contoso").ConfigDir, "cliextensions")
 	if err := os.MkdirAll(sub, 0755); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	if err := os.Symlink(sub, azurePath(t, home)); err != nil {
-		t.Fatalf("preparando enlace: %v", err)
+		t.Fatalf("setup link: %v", err)
 	}
 	info, err := config.ResolveDefault(cfg)
 	if err != nil {
 		t.Fatalf("ResolveDefault: %v", err)
 	}
 	if info.State != config.DefaultForeign {
-		t.Errorf("State = %v, quería DefaultForeign (apunta dentro del tenant, no al tenant)", info.State)
+		t.Errorf("State = %v, wanted DefaultForeign (points inside the tenant, not at the tenant)", info.State)
 	}
 }
 
-// AzureDir necesita HOME para poder situar ~/.azure.
+// AzureDir needs HOME to locate ~/.azure.
 func TestAzureDirNeedsHome(t *testing.T) {
 	t.Setenv("HOME", "")
 	if _, err := config.AzureDir(); err == nil {
-		t.Fatal("AzureDir devolvió nil sin HOME")
+		t.Fatal("AzureDir returned nil with no HOME")
 	}
 }
 
-// Un fallo al resolver el destino del enlace que NO sea «no existe» —aquí un
-// componente de la ruta que es un fichero, no un directorio— debe propagarse
-// como error, no confundirse con un enlace roto.
+// A failure to resolve the link target that is NOT "does not exist" — here a
+// path component that is a file, not a directory — must propagate as an error,
+// not be confused with a broken link.
 func TestResolveDefaultTargetStatError(t *testing.T) {
 	home, cfg := azureSandbox(t)
-	// Un fichero donde debería haber un directorio, y el enlace apunta a algo
-	// por debajo de él: Stat falla con ENOTDIR, que no es IsNotExist.
-	blocker := filepath.Join(t.TempDir(), "fichero")
+	// A file where a directory should be, and the link points at something
+	// below it: Stat fails with ENOTDIR, which is not IsNotExist.
+	blocker := filepath.Join(t.TempDir(), "file")
 	if err := os.WriteFile(blocker, nil, 0644); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	if err := os.Symlink(filepath.Join(blocker, "dentro"), azurePath(t, home)); err != nil {
-		t.Fatalf("preparando enlace: %v", err)
+		t.Fatalf("setup link: %v", err)
 	}
 	_, err := config.ResolveDefault(cfg)
 	if err == nil {
-		t.Fatal("ResolveDefault no propagó el error de Stat del destino")
+		t.Fatal("ResolveDefault did not propagate the target's Stat error")
 	}
 }

--- a/internal/config/errors_test.go
+++ b/internal/config/errors_test.go
@@ -10,29 +10,29 @@ import (
 	"github.com/aolmosj/azsel/internal/config"
 )
 
-// unusableHome apunta AZSEL_HOME a una ruta que cuelga de un fichero. Todo
-// intento de crear directorios ahí falla con ENOTDIR. Es más fiable que jugar
-// con permisos: root los ignoraría.
+// unusableHome points AZSEL_HOME at a path hanging off a file. Any attempt to
+// create directories there fails with ENOTDIR. It is more reliable than
+// playing with permissions: root would ignore them.
 func unusableHome(t *testing.T) {
 	t.Helper()
-	blocker := filepath.Join(t.TempDir(), "soy-un-fichero")
+	blocker := filepath.Join(t.TempDir(), "a-file")
 	if err := os.WriteFile(blocker, nil, 0644); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	t.Setenv(config.EnvHome, filepath.Join(blocker, "azsel"))
 }
 
 func TestBaseDirFailsWithoutHome(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("azsel solo se publica para linux y darwin")
+		t.Skip("azsel is only published for linux and darwin")
 	}
 	t.Setenv(config.EnvHome, "")
 	t.Setenv("HOME", "")
 
 	if _, err := config.BaseDir(); err == nil {
-		t.Fatal("BaseDir devolvió nil sin HOME definido")
+		t.Fatal("BaseDir returned nil with no HOME defined")
 	} else if !strings.Contains(err.Error(), "home directory") {
-		t.Errorf("error = %q, quería que mencionara el home", err)
+		t.Errorf("error = %q, wanted it to mention the home", err)
 	}
 }
 
@@ -65,68 +65,70 @@ func TestEnsureFuncsFailOnUnusableBaseDir(t *testing.T) {
 			unusableHome(t)
 			err := c.call()
 			if err == nil {
-				t.Fatalf("%s devolvió nil sobre un directorio base inservible", c.name)
+				t.Fatalf("%s returned nil on an unusable base directory", c.name)
 			}
 			if c.want != "" && !strings.Contains(err.Error(), c.want) {
-				t.Errorf("error = %q, quería que mencionara %q", err, c.want)
+				t.Errorf("error = %q, wanted it to mention %q", err, c.want)
 			}
 		})
 	}
 }
 
-// Un config.json que resulta ser un directorio no es «no existe»: es un error
-// de lectura real y Load debe propagarlo en vez de devolver config vacía.
+// A config.json that turns out to be a directory is not "does not exist": it
+// is a real read error and Load must propagate it instead of returning an
+// empty config.
 func TestLoadFailsWhenConfigPathIsADirectory(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv(config.EnvHome, dir)
 	if err := os.MkdirAll(filepath.Join(dir, "config.json"), 0755); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 
 	if _, err := config.Load(); err == nil {
-		t.Fatal("Load devolvió nil con config.json siendo un directorio")
+		t.Fatal("Load returned nil with config.json being a directory")
 	} else if !strings.Contains(err.Error(), "reading config") {
-		t.Errorf("error = %q, quería que mencionara «reading config»", err)
+		t.Errorf("error = %q, wanted it to mention 'reading config'", err)
 	}
 }
 
-// Una ruta ocupada por un fichero no es un perfil existente. os.Stat tiene
-// éxito sobre un fichero, así que sin comprobar IsDir se colaría como
-// «ya existe» y el fallo aparecería mucho después, dentro de az.
+// A path taken by a file is not an existing profile. os.Stat succeeds on a
+// file, so without checking IsDir it would slip through as "already exists"
+// and the failure would surface much later, inside az.
 func TestEnsureTenantDirRejectsPathTakenByAFile(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv(config.EnvHome, dir)
 	tenants := filepath.Join(dir, "tenants")
 	if err := os.MkdirAll(tenants, 0755); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(tenants, "acme"), nil, 0644); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 
 	_, created, err := config.EnsureTenantDir("acme")
 	if err == nil {
-		t.Fatal("EnsureTenantDir devolvió nil sobre una ruta ocupada por un fichero")
+		t.Fatal("EnsureTenantDir returned nil on a path taken by a file")
 	}
 	if !strings.Contains(err.Error(), "not a directory") {
-		t.Errorf("error = %q, quería que mencionara «not a directory»", err)
+		t.Errorf("error = %q, wanted it to mention 'not a directory'", err)
 	}
-	// Nada creado: un rollback futuro (#9) no debe borrar lo que no puso él.
+	// Nothing created: a future rollback (#9) must not delete what it did not
+	// put there.
 	if created {
-		t.Error("created = true, quería false")
+		t.Error("created = true, wanted false")
 	}
 }
 
-// Lo mismo para el directorio base y el de extensiones.
+// The same for the base directory and the extensions one.
 func TestEnsureDirsRejectPathTakenByAFile(t *testing.T) {
 	t.Run("base", func(t *testing.T) {
 		blocker := filepath.Join(t.TempDir(), "azsel")
 		if err := os.WriteFile(blocker, nil, 0644); err != nil {
-			t.Fatalf("preparando: %v", err)
+			t.Fatalf("setup: %v", err)
 		}
 		t.Setenv(config.EnvHome, blocker)
 		if _, err := config.EnsureBaseDir(); err == nil {
-			t.Fatal("EnsureBaseDir devolvió nil sobre un fichero")
+			t.Fatal("EnsureBaseDir returned nil on a file")
 		}
 	})
 
@@ -134,10 +136,10 @@ func TestEnsureDirsRejectPathTakenByAFile(t *testing.T) {
 		dir := t.TempDir()
 		t.Setenv(config.EnvHome, dir)
 		if err := os.WriteFile(filepath.Join(dir, "extensions"), nil, 0644); err != nil {
-			t.Fatalf("preparando: %v", err)
+			t.Fatalf("setup: %v", err)
 		}
 		if _, err := config.EnsureExtensionsDir(); err == nil {
-			t.Fatal("EnsureExtensionsDir devolvió nil sobre un fichero")
+			t.Fatal("EnsureExtensionsDir returned nil on a file")
 		}
 	})
 }
@@ -151,6 +153,6 @@ func TestWriteEnvWithDebugEnabled(t *testing.T) {
 		t.Fatalf("WriteEnv: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(dir, ".switch")); err != nil {
-		t.Fatalf("no se escribió .switch: %v", err)
+		t.Fatalf(".switch was not written: %v", err)
 	}
 }

--- a/internal/config/setdefault_test.go
+++ b/internal/config/setdefault_test.go
@@ -16,14 +16,14 @@ func assertLinkTo(t *testing.T, home, want string) {
 	azure := filepath.Join(home, ".azure")
 	fi, err := os.Lstat(azure)
 	if err != nil {
-		t.Fatalf("~/.azure no existe: %v", err)
+		t.Fatalf("~/.azure does not exist: %v", err)
 	}
 	if fi.Mode()&os.ModeSymlink == 0 {
-		t.Fatalf("~/.azure no es un enlace")
+		t.Fatalf("~/.azure is not a link")
 	}
 	got, _ := os.Readlink(azure)
 	if got != want {
-		t.Errorf("~/.azure -> %q, quería %q", got, want)
+		t.Errorf("~/.azure -> %q, wanted %q", got, want)
 	}
 }
 
@@ -34,24 +34,24 @@ func TestSetDefaultFromNothing(t *testing.T) {
 		t.Fatalf("SetDefault: %v", err)
 	}
 	if res.BackupPath != "" {
-		t.Errorf("BackupPath = %q, no debía respaldar nada", res.BackupPath)
+		t.Errorf("BackupPath = %q, should not back up anything", res.BackupPath)
 	}
 	if res.Repointed {
-		t.Error("Repointed = true en creación fresca")
+		t.Error("Repointed = true on fresh creation")
 	}
 	assertLinkTo(t, home, cfg.FindTenant("contoso").ConfigDir)
 }
 
-// El caso que motiva #29: ~/.azure es un directorio real con contenido.
+// The case behind #29: ~/.azure is a real directory with content.
 func TestSetDefaultBacksUpRealDirectory(t *testing.T) {
 	home, cfg := azureSandbox(t, "contoso")
 	azure := filepath.Join(home, ".azure")
 	if err := os.MkdirAll(azure, 0755); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	marker := filepath.Join(azure, "msal_token_cache.json")
-	if err := os.WriteFile(marker, []byte("sesión valiosa"), 0600); err != nil {
-		t.Fatalf("preparando: %v", err)
+	if err := os.WriteFile(marker, []byte("valuable session"), 0600); err != nil {
+		t.Fatalf("setup: %v", err)
 	}
 
 	res, err := config.SetDefault(cfg, "contoso", ts)
@@ -59,15 +59,15 @@ func TestSetDefaultBacksUpRealDirectory(t *testing.T) {
 		t.Fatalf("SetDefault: %v", err)
 	}
 	if res.BackupPath == "" {
-		t.Fatal("no se reportó backup pese a haber un ~/.azure real")
+		t.Fatal("no backup reported despite a real ~/.azure")
 	}
-	// La sesión se conserva en el backup, no se destruye.
+	// The session is preserved in the backup, not destroyed.
 	data, err := os.ReadFile(filepath.Join(res.BackupPath, "msal_token_cache.json"))
 	if err != nil {
-		t.Fatalf("el contenido no sobrevivió al backup: %v", err)
+		t.Fatalf("the content did not survive the backup: %v", err)
 	}
-	if string(data) != "sesión valiosa" {
-		t.Errorf("contenido del backup = %q", data)
+	if string(data) != "valuable session" {
+		t.Errorf("backup content = %q", data)
 	}
 	assertLinkTo(t, home, cfg.FindTenant("contoso").ConfigDir)
 }
@@ -75,61 +75,61 @@ func TestSetDefaultBacksUpRealDirectory(t *testing.T) {
 func TestSetDefaultRepointsOwnLink(t *testing.T) {
 	home, cfg := azureSandbox(t, "contoso", "fabrikam")
 	if _, err := config.SetDefault(cfg, "contoso", ts); err != nil {
-		t.Fatalf("primer SetDefault: %v", err)
+		t.Fatalf("first SetDefault: %v", err)
 	}
 	res, err := config.SetDefault(cfg, "fabrikam", ts)
 	if err != nil {
-		t.Fatalf("segundo SetDefault: %v", err)
+		t.Fatalf("second SetDefault: %v", err)
 	}
 	if !res.Repointed {
-		t.Error("Repointed = false al mover un enlace existente")
+		t.Error("Repointed = false when moving an existing link")
 	}
 	if res.BackupPath != "" {
-		t.Error("se respaldó al repuntar un enlace propio; no debía")
+		t.Error("backed up when repointing our own link; should not have")
 	}
 	assertLinkTo(t, home, cfg.FindTenant("fabrikam").ConfigDir)
 }
 
-// Un enlace ajeno no se toca.
+// A foreign link is not touched.
 func TestSetDefaultRefusesForeignLink(t *testing.T) {
 	home, cfg := azureSandbox(t, "contoso")
 	outside := t.TempDir()
 	azure := filepath.Join(home, ".azure")
 	if err := os.Symlink(outside, azure); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	_, err := config.SetDefault(cfg, "contoso", ts)
 	if err == nil {
-		t.Fatal("SetDefault pisó un enlace ajeno")
+		t.Fatal("SetDefault clobbered a foreign link")
 	}
-	// El enlace ajeno sigue intacto.
+	// The foreign link is still intact.
 	got, _ := os.Readlink(azure)
 	if got != outside {
-		t.Errorf("el enlace ajeno cambió a %q", got)
+		t.Errorf("the foreign link changed to %q", got)
 	}
 }
 
 func TestSetDefaultRejectsUnknownTenant(t *testing.T) {
 	_, cfg := azureSandbox(t, "contoso")
-	if _, err := config.SetDefault(cfg, "fantasma", ts); err == nil {
-		t.Fatal("SetDefault aceptó un tenant inexistente")
+	if _, err := config.SetDefault(cfg, "ghost", ts); err == nil {
+		t.Fatal("SetDefault accepted a nonexistent tenant")
 	}
 }
 
-// Reemplaza un enlace roto que era nuestro (apuntaba a un tenant borrado).
+// Replaces a broken link that was ours (pointed at a deleted tenant).
 func TestSetDefaultReplacesOwnBrokenLink(t *testing.T) {
 	home, cfg := azureSandbox(t, "contoso", "fabrikam")
 	azure := filepath.Join(home, ".azure")
-	// Enlace a un tenant que luego borramos: queda colgando pero es nuestro.
+	// Link to a tenant we then delete: it dangles but is ours.
 	gone := cfg.FindTenant("fabrikam").ConfigDir
 	if err := os.Symlink(gone, azure); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	if err := os.RemoveAll(gone); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	if _, err := config.SetDefault(cfg, "contoso", ts); err != nil {
-		t.Fatalf("SetDefault sobre enlace roto propio: %v", err)
+		t.Fatalf("SetDefault on our own broken link: %v", err)
 	}
 	assertLinkTo(t, home, cfg.FindTenant("contoso").ConfigDir)
 }
@@ -143,28 +143,28 @@ func TestSetDefaultCreatesSharedExtensionsLink(t *testing.T) {
 	link := filepath.Join(cfg.FindTenant("contoso").ConfigDir, "cliextensions")
 	got, err := os.Readlink(link)
 	if err != nil {
-		t.Fatalf("cliextensions no es enlace: %v", err)
+		t.Fatalf("cliextensions is not a link: %v", err)
 	}
 	if got != shared {
-		t.Errorf("cliextensions -> %q, quería el compartido %q", got, shared)
+		t.Errorf("cliextensions -> %q, wanted the shared %q", got, shared)
 	}
 }
 
-// Un cliextensions real preexistente (restos) se aparta, no se borra.
+// A preexisting real cliextensions (leftovers) is moved aside, not deleted.
 func TestSetDefaultMovesAsideStaleExtensions(t *testing.T) {
 	_, cfg := azureSandbox(t, "contoso")
 	stale := filepath.Join(cfg.FindTenant("contoso").ConfigDir, "cliextensions")
 	if err := os.MkdirAll(stale, 0755); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(stale, "vieja.txt"), []byte("x"), 0644); err != nil {
-		t.Fatalf("preparando: %v", err)
+	if err := os.WriteFile(filepath.Join(stale, "old.txt"), []byte("x"), 0644); err != nil {
+		t.Fatalf("setup: %v", err)
 	}
 	if _, err := config.SetDefault(cfg, "contoso", ts); err != nil {
 		t.Fatalf("SetDefault: %v", err)
 	}
 	if _, err := os.Stat(stale + ".bak"); err != nil {
-		t.Errorf("los restos no se apartaron a .bak: %v", err)
+		t.Errorf("the leftovers were not moved aside to .bak: %v", err)
 	}
 }
 
@@ -178,10 +178,10 @@ func TestClearDefault(t *testing.T) {
 		t.Fatalf("ClearDefault: %v", err)
 	}
 	if !res.Cleared {
-		t.Error("Cleared = false pese a haber un default")
+		t.Error("Cleared = false despite a default")
 	}
 	if _, err := os.Lstat(filepath.Join(home, ".azure")); !os.IsNotExist(err) {
-		t.Errorf("~/.azure sigue existiendo tras clear (err=%v)", err)
+		t.Errorf("~/.azure still exists after clear (err=%v)", err)
 	}
 }
 
@@ -189,7 +189,7 @@ func TestClearDefaultReportsLatestBackup(t *testing.T) {
 	home, cfg := azureSandbox(t, "contoso")
 	azure := filepath.Join(home, ".azure")
 	if err := os.MkdirAll(azure, 0755); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	if _, err := config.SetDefault(cfg, "contoso", ts); err != nil {
 		t.Fatalf("SetDefault: %v", err)
@@ -199,7 +199,7 @@ func TestClearDefaultReportsLatestBackup(t *testing.T) {
 		t.Fatalf("ClearDefault: %v", err)
 	}
 	if res.LatestBackup == "" {
-		t.Error("clear no reportó el backup existente")
+		t.Error("clear did not report the existing backup")
 	}
 }
 
@@ -207,31 +207,31 @@ func TestClearDefaultNoDefault(t *testing.T) {
 	_, cfg := azureSandbox(t)
 	res, err := config.ClearDefault(cfg)
 	if err != nil {
-		t.Fatalf("ClearDefault sin default: %v", err)
+		t.Fatalf("ClearDefault with no default: %v", err)
 	}
 	if res.Cleared {
-		t.Error("Cleared = true sin default")
+		t.Error("Cleared = true with no default")
 	}
 }
 
-// clear no debe tocar el ~/.azure nativo de az.
+// clear must not touch az's native ~/.azure.
 func TestClearDefaultLeavesNativeDirectory(t *testing.T) {
 	home, cfg := azureSandbox(t)
 	azure := filepath.Join(home, ".azure")
 	if err := os.MkdirAll(azure, 0755); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	if _, err := config.ClearDefault(cfg); err != nil {
 		t.Fatalf("ClearDefault: %v", err)
 	}
 	if _, err := os.Stat(azure); err != nil {
-		t.Errorf("clear borró el ~/.azure nativo: %v", err)
+		t.Errorf("clear deleted the native ~/.azure: %v", err)
 	}
 }
 
-// La renombrada del enlace es atómica: nunca hay un instante sin ~/.azure.
-// Aquí lo que se comprueba es que un enlace previo se reemplaza sin pasar por
-// un estado inexistente observable — al menos que el resultado sea correcto.
+// The link rename is atomic: there is never a moment without ~/.azure. What is
+// checked here is that a previous link is replaced without passing through an
+// observable nonexistent state — at least that the result is correct.
 func TestReplaceIsAtomicResult(t *testing.T) {
 	home, cfg := azureSandbox(t, "a", "b")
 	if _, err := config.SetDefault(cfg, "a", ts); err != nil {
@@ -240,10 +240,10 @@ func TestReplaceIsAtomicResult(t *testing.T) {
 	if _, err := config.SetDefault(cfg, "b", ts); err != nil {
 		t.Fatalf("set b: %v", err)
 	}
-	// No debe quedar ningún fichero temporal.
+	// No temporary file must be left behind.
 	azure := filepath.Join(home, ".azure")
 	if _, err := os.Lstat(azure + ".azsel-tmp." + itoa(os.Getpid())); !os.IsNotExist(err) {
-		t.Error("quedó un enlace temporal")
+		t.Error("a temporary link was left behind")
 	}
 	assertLinkTo(t, home, cfg.FindTenant("b").ConfigDir)
 }
@@ -271,10 +271,10 @@ func TestClearDefaultRefusesForeign(t *testing.T) {
 	home, cfg := azureSandbox(t)
 	outside := t.TempDir()
 	if err := os.Symlink(outside, filepath.Join(home, ".azure")); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	if _, err := config.ClearDefault(cfg); err == nil {
-		t.Fatal("ClearDefault tocó un enlace ajeno")
+		t.Fatal("ClearDefault touched a foreign link")
 	}
 }
 
@@ -282,54 +282,54 @@ func TestClearDefaultRemovesOwnBrokenLink(t *testing.T) {
 	home, cfg := azureSandbox(t, "contoso")
 	gone := cfg.FindTenant("contoso").ConfigDir
 	if err := os.Symlink(gone, filepath.Join(home, ".azure")); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	if err := os.RemoveAll(gone); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	res, err := config.ClearDefault(cfg)
 	if err != nil {
-		t.Fatalf("ClearDefault sobre enlace roto propio: %v", err)
+		t.Fatalf("ClearDefault on our own broken link: %v", err)
 	}
 	if !res.Cleared {
-		t.Error("no se limpió un enlace roto que era nuestro")
+		t.Error("a broken link that was ours was not cleared")
 	}
 	if _, err := os.Lstat(filepath.Join(home, ".azure")); !os.IsNotExist(err) {
-		t.Error("el enlace roto sigue ahí")
+		t.Error("the broken link is still there")
 	}
 }
 
-// clear NO debe limpiar un enlace roto ajeno.
+// clear must NOT clear a foreign broken link.
 func TestClearDefaultLeavesForeignBrokenLink(t *testing.T) {
 	home, cfg := azureSandbox(t)
-	outside := filepath.Join(t.TempDir(), "no-existe")
+	outside := filepath.Join(t.TempDir(), "missing")
 	if err := os.Symlink(outside, filepath.Join(home, ".azure")); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	res, err := config.ClearDefault(cfg)
 	if err != nil {
 		t.Fatalf("ClearDefault: %v", err)
 	}
 	if res.Cleared {
-		t.Error("se limpió un enlace roto ajeno")
+		t.Error("a foreign broken link was cleared")
 	}
 }
 
-// El backup reportado es el más reciente cuando hay varios.
+// The reported backup is the most recent when there are several.
 func TestClearReportsNewestOfSeveralBackups(t *testing.T) {
 	home, cfg := azureSandbox(t, "contoso")
 	backups := filepath.Join(home, ".azsel", "backups")
 	if err := os.MkdirAll(backups, 0700); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	for _, name := range []string{"azure-20260101-000000", "azure-20260115-000000"} {
 		if err := os.MkdirAll(filepath.Join(backups, name), 0700); err != nil {
-			t.Fatalf("preparando: %v", err)
+			t.Fatalf("setup: %v", err)
 		}
 	}
-	// ~/.azure real, para que SetDefault genere un backup con marca posterior.
+	// real ~/.azure, so SetDefault generates a backup with a later stamp.
 	if err := os.MkdirAll(filepath.Join(home, ".azure"), 0755); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 	if _, err := config.SetDefault(cfg, "contoso", "20260220-120001"); err != nil {
 		t.Fatalf("SetDefault: %v", err)
@@ -339,46 +339,46 @@ func TestClearReportsNewestOfSeveralBackups(t *testing.T) {
 		t.Fatalf("ClearDefault: %v", err)
 	}
 	if filepath.Base(res.LatestBackup) != "azure-20260220-120001" {
-		t.Errorf("LatestBackup = %q, quería el más reciente", filepath.Base(res.LatestBackup))
+		t.Errorf("LatestBackup = %q, wanted the most recent", filepath.Base(res.LatestBackup))
 	}
 }
 
-// Bug del review: si EnsureSharedExtensionsLink falla, ~/.azure no debe haber
-// sido ya movido a backup. El enlace de extensiones va antes de tocar
-// ~/.azure, así que un fallo suyo deja ~/.azure intacto.
+// Review bug: if EnsureSharedExtensionsLink fails, ~/.azure must not have been
+// moved to backup already. The extensions link comes before touching
+// ~/.azure, so a failure there leaves ~/.azure intact.
 func TestSetDefaultDoesNotBackUpIfExtensionsLinkFails(t *testing.T) {
 	home, cfg := azureSandbox(t, "contoso")
 	azure := filepath.Join(home, ".azure")
 	if err := os.MkdirAll(azure, 0755); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(azure, "tok"), []byte("sesión"), 0600); err != nil {
-		t.Fatalf("preparando: %v", err)
+	if err := os.WriteFile(filepath.Join(azure, "tok"), []byte("session"), 0600); err != nil {
+		t.Fatalf("setup: %v", err)
 	}
-	// Forzamos el fallo de EnsureSharedExtensionsLink: un fichero donde debería
-	// ir el directorio compartido de extensiones hace fallar su creación.
+	// Force EnsureSharedExtensionsLink to fail: a file where the shared
+	// extensions directory should go makes its creation fail.
 	extPath := filepath.Join(home, ".azsel", "extensions")
 	_ = os.RemoveAll(extPath)
 	if err := os.WriteFile(extPath, nil, 0644); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 
 	if _, err := config.SetDefault(cfg, "contoso", "20260220-120000"); err == nil {
-		t.Fatal("SetDefault no falló pese al error de extensiones")
+		t.Fatal("SetDefault did not fail despite the extensions error")
 	}
-	// ~/.azure sigue siendo el directorio real, no un enlace ni desaparecido.
+	// ~/.azure is still the real directory, not a link nor gone.
 	fi, err := os.Lstat(azure)
 	if err != nil {
-		t.Fatalf("~/.azure desapareció pese al fallo: %v", err)
+		t.Fatalf("~/.azure disappeared despite the failure: %v", err)
 	}
 	if fi.Mode()&os.ModeSymlink != 0 {
-		t.Error("~/.azure se convirtió en enlace pese al fallo de extensiones")
+		t.Error("~/.azure became a link despite the extensions failure")
 	}
 	if _, err := os.Stat(filepath.Join(azure, "tok")); err != nil {
-		t.Error("el contenido de ~/.azure no sobrevivió: la sesión se movió sin enlace nuevo")
+		t.Error("the content of ~/.azure did not survive: the session was moved without a new link")
 	}
-	// Y no debe haber quedado un backup.
+	// And no backup must have been left.
 	if entries, _ := os.ReadDir(filepath.Join(home, ".azsel", "backups")); len(entries) > 0 {
-		t.Error("se creó un backup pese a que la operación falló")
+		t.Error("a backup was created despite the operation failing")
 	}
 }

--- a/internal/config/switch_test.go
+++ b/internal/config/switch_test.go
@@ -19,12 +19,12 @@ func TestEnvFileHonoursSwitchFileVar(t *testing.T) {
 		t.Fatalf("EnvFile: %v", err)
 	}
 	if got != want {
-		t.Errorf("EnvFile = %q, quería %q", got, want)
+		t.Errorf("EnvFile = %q, wanted %q", got, want)
 	}
 }
 
-// El fallback mantiene funcionando a los wrappers instalados antes de #4 y al
-// patrón de scripts documentado en el README.
+// The fallback keeps working for wrappers installed before #4 and for the
+// scripting pattern documented in the README.
 func TestEnvFileFallsBackToLegacyPath(t *testing.T) {
 	dir := sandbox(t)
 	t.Setenv(config.EnvSwitchFile, "")
@@ -34,7 +34,7 @@ func TestEnvFileFallsBackToLegacyPath(t *testing.T) {
 		t.Fatalf("EnvFile: %v", err)
 	}
 	if want := filepath.Join(dir, ".switch"); got != want {
-		t.Errorf("EnvFile = %q, quería %q", got, want)
+		t.Errorf("EnvFile = %q, wanted %q", got, want)
 	}
 }
 
@@ -50,19 +50,19 @@ func TestWriteEnvUsesSwitchFileVar(t *testing.T) {
 
 	data, err := os.ReadFile(target)
 	if err != nil {
-		t.Fatalf("leyendo el destino: %v", err)
+		t.Fatalf("reading the target: %v", err)
 	}
 	if string(data) != lines {
-		t.Errorf("contenido = %q, quería %q", data, lines)
+		t.Errorf("content = %q, wanted %q", data, lines)
 	}
-	// No debe escribir además en la ruta antigua.
+	// It must not also write to the old path.
 	if _, err := os.Stat(filepath.Join(base, ".switch")); !os.IsNotExist(err) {
-		t.Error("WriteEnv escribió también en el .switch heredado")
+		t.Error("WriteEnv also wrote to the legacy .switch")
 	}
 }
 
-// El escenario que motiva #4: dos shells cambiando de tenant a la vez. Antes
-// compartían fichero, así que una consumía el switch de la otra.
+// The scenario behind #4: two shells switching tenant at once. They used to
+// share a file, so one consumed the other's switch.
 func TestConcurrentShellsDoNotShareSwitchFile(t *testing.T) {
 	base := sandbox(t)
 
@@ -75,9 +75,9 @@ func TestConcurrentShellsDoNotShareSwitchFile(t *testing.T) {
 		return path
 	}
 
-	// La shell A escribe su switch y todavía no lo ha sourceado.
+	// Shell A writes its switch and has not sourced it yet.
 	pathA := write("1001", "acme")
-	// La shell B ejecuta azsel entretanto.
+	// Shell B runs azsel in the meantime.
 	pathB := write("1002", "globex")
 
 	for _, c := range []struct{ path, want string }{
@@ -86,10 +86,10 @@ func TestConcurrentShellsDoNotShareSwitchFile(t *testing.T) {
 	} {
 		data, err := os.ReadFile(c.path)
 		if err != nil {
-			t.Fatalf("leyendo %s: %v", c.path, err)
+			t.Fatalf("reading %s: %v", c.path, err)
 		}
 		if got := string(data); got != "export AZURE_CONFIG_DIR="+c.want+"\n" {
-			t.Errorf("%s contiene %q, quería %s", c.path, got, c.want)
+			t.Errorf("%s contains %q, wanted %s", c.path, got, c.want)
 		}
 	}
 }
@@ -97,7 +97,7 @@ func TestConcurrentShellsDoNotShareSwitchFile(t *testing.T) {
 func TestWriteEnvPrunesStaleSwitchFiles(t *testing.T) {
 	base := sandbox(t)
 	if _, err := config.EnsureBaseDir(); err != nil {
-		t.Fatalf("preparando: %v", err)
+		t.Fatalf("setup: %v", err)
 	}
 
 	stale := filepath.Join(base, ".switch.1234")
@@ -105,13 +105,13 @@ func TestWriteEnvPrunesStaleSwitchFiles(t *testing.T) {
 	legacy := filepath.Join(base, ".switch")
 	for _, p := range []string{stale, fresh, legacy} {
 		if err := os.WriteFile(p, []byte("export FOO=bar\n"), 0600); err != nil {
-			t.Fatalf("preparando %s: %v", p, err)
+			t.Fatalf("setup %s: %v", p, err)
 		}
 	}
 	old := time.Now().Add(-48 * time.Hour)
 	for _, p := range []string{stale, legacy} {
 		if err := os.Chtimes(p, old, old); err != nil {
-			t.Fatalf("envejeciendo %s: %v", p, err)
+			t.Fatalf("aging %s: %v", p, err)
 		}
 	}
 
@@ -121,19 +121,19 @@ func TestWriteEnvPrunesStaleSwitchFiles(t *testing.T) {
 	}
 
 	if _, err := os.Stat(stale); !os.IsNotExist(err) {
-		t.Error("no se podó el fichero de switch huérfano")
+		t.Error("the orphan switch file was not pruned")
 	}
 	if _, err := os.Stat(fresh); err != nil {
-		t.Error("se podó un fichero de switch reciente")
+		t.Error("a recent switch file was pruned")
 	}
-	// El .switch heredado se respeta: un wrapper antiguo puede estar a punto
-	// de sourcearlo.
+	// The legacy .switch is respected: an old wrapper may be about to source
+	// it.
 	if _, err := os.Stat(legacy); err != nil {
-		t.Error("se podó el .switch heredado")
+		t.Error("the legacy .switch was pruned")
 	}
 }
 
-// La poda es best-effort: si falla, el cambio de tenant no debe fallar.
+// Pruning is best-effort: if it fails, the tenant switch must not fail.
 func TestWriteEnvSucceedsWhenPruneCannotRead(t *testing.T) {
 	target := filepath.Join(t.TempDir(), ".switch.1")
 	t.Setenv(config.EnvHome, filepath.Join(t.TempDir(), "no", "existe"))
@@ -143,6 +143,6 @@ func TestWriteEnvSucceedsWhenPruneCannotRead(t *testing.T) {
 		t.Fatalf("WriteEnv: %v", err)
 	}
 	if _, err := os.Stat(target); err != nil {
-		t.Fatalf("no se escribió el switch: %v", err)
+		t.Fatalf("the switch was not written: %v", err)
 	}
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -25,8 +25,8 @@ func keyMsg(s string) tea.KeyMsg {
 	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
 }
 
-// send aplica una secuencia de mensajes y devuelve el modelo resultante junto
-// al último comando emitido.
+// send applies a sequence of messages and returns the resulting model along
+// with the last command emitted.
 func send(t *testing.T, m Model, msgs ...tea.Msg) (Model, tea.Cmd) {
 	t.Helper()
 	var cmd tea.Cmd
@@ -34,28 +34,28 @@ func send(t *testing.T, m Model, msgs ...tea.Msg) (Model, tea.Cmd) {
 		next, c := m.Update(msg)
 		got, ok := next.(Model)
 		if !ok {
-			t.Fatalf("Update devolvió %T, quería tui.Model", next)
+			t.Fatalf("Update returned %T, wanted tui.Model", next)
 		}
 		m, cmd = got, c
 	}
 	return m, cmd
 }
 
-// El tenant activo se deduce comparando ConfigDir con AZURE_CONFIG_DIR. No se
-// guarda en ningún sitio, lo que permite que cada terminal tenga el suyo.
+// The active tenant is inferred by comparing ConfigDir with AZURE_CONFIG_DIR.
+// It is stored nowhere, which lets each terminal have its own.
 func TestNewModelMarksActiveTenant(t *testing.T) {
 	ts := tenants()
 	m := NewModel(ts, ts[1].ConfigDir, "", nil)
 
 	items := m.list.Items()
 	if len(items) != 2 {
-		t.Fatalf("%d items, quería 2", len(items))
+		t.Fatalf("%d items, wanted 2", len(items))
 	}
 	if items[0].(TenantItem).active {
-		t.Error("acme marcado como activo")
+		t.Error("acme marked as active")
 	}
 	if !items[1].(TenantItem).active {
-		t.Error("globex no marcado como activo")
+		t.Error("globex not marked as active")
 	}
 }
 
@@ -64,7 +64,7 @@ func TestNewModelNoActiveTenant(t *testing.T) {
 		m := NewModel(tenants(), dir, "", nil)
 		for _, it := range m.list.Items() {
 			if it.(TenantItem).active {
-				t.Errorf("con AZURE_CONFIG_DIR=%q hay un tenant marcado activo", dir)
+				t.Errorf("with AZURE_CONFIG_DIR=%q a tenant is marked active", dir)
 			}
 		}
 	}
@@ -73,7 +73,7 @@ func TestNewModelNoActiveTenant(t *testing.T) {
 func TestSelectedIsNilUntilChosen(t *testing.T) {
 	m := NewModel(tenants(), "", "", nil)
 	if got := m.Selected(); got != nil {
-		t.Errorf("Selected() = %+v antes de elegir, quería nil", got)
+		t.Errorf("Selected() = %+v before choosing, wanted nil", got)
 	}
 }
 
@@ -84,27 +84,27 @@ func TestSelectTenantMsgSetsSelection(t *testing.T) {
 
 	got := m.Selected()
 	if got == nil {
-		t.Fatal("Selected() = nil tras seleccionar")
+		t.Fatal("Selected() = nil after selecting")
 	}
 	if got.Name != "globex" {
-		t.Errorf("Selected().Name = %q, quería «globex»", got.Name)
+		t.Errorf("Selected().Name = %q, wanted globex", got.Name)
 	}
-	// Sale de la TUI y deja de pintar.
+	// Exits the TUI and stops rendering.
 	if v := m.View(); v != "" {
-		t.Errorf("View() = %q tras seleccionar, quería vacío", v)
+		t.Errorf("View() = %q after selecting, wanted empty", v)
 	}
 }
 
-// Pulsar enter sobre un item debe emitir selectTenantMsg. Es el delegate quien
-// lo produce, no el modelo.
+// Pressing enter on an item must emit selectTenantMsg. The delegate produces
+// it, not the model.
 func TestEnterEmitsSelectTenantMsg(t *testing.T) {
 	m := NewModel(tenants(), "", "", nil)
 	_, cmd := send(t, m, keyMsg("enter"))
 	if cmd == nil {
-		t.Fatal("enter no emitió ningún comando")
+		t.Fatal("enter emitted no command")
 	}
 	if _, ok := cmd().(selectTenantMsg); !ok {
-		t.Fatalf("enter emitió %T, quería selectTenantMsg", cmd())
+		t.Fatalf("enter emitted %T, wanted selectTenantMsg", cmd())
 	}
 }
 
@@ -113,41 +113,41 @@ func TestQuitKeys(t *testing.T) {
 		m := NewModel(tenants(), "", "", nil)
 		m, _ = send(t, m, k)
 		if v := m.View(); v != "" {
-			t.Errorf("tras %v, View() = %q, quería vacío", k, v)
+			t.Errorf("after %v, View() = %q, wanted empty", k, v)
 		}
 		if m.Selected() != nil {
-			t.Errorf("tras %v hay selección, quería nil", k)
+			t.Errorf("after %v there is a selection, wanted nil", k)
 		}
 	}
 }
 
-// Protege la guarda de Update: mientras se filtra, «q» es texto de búsqueda,
-// no la orden de salir. Sin ella, buscar «quux» cerraría la aplicación.
+// Protects Update's guard: while filtering, "q" is search text, not the quit
+// command. Without it, searching for "quux" would close the application.
 func TestQuitKeyIsTextWhileFiltering(t *testing.T) {
 	m := NewModel(tenants(), "", "", nil)
 	m, _ = send(t, m, keyMsg("/"))
 	if m.list.FilterState() != list.Filtering {
-		t.Fatalf("«/» no entró en modo filtro: estado = %v", m.list.FilterState())
+		t.Fatalf("\"/\" did not enter filter mode: state = %v", m.list.FilterState())
 	}
 
 	m, _ = send(t, m, keyMsg("q"))
 	if v := m.View(); v == "" {
-		t.Error("«q» durante el filtrado cerró la TUI")
+		t.Error("\"q\" while filtering closed the TUI")
 	}
 	if m.Selected() != nil {
-		t.Error("«q» durante el filtrado dejó una selección")
+		t.Error("\"q\" while filtering left a selection")
 	}
 }
 
-// El filtro busca por nombre y por ID: pegar un GUID debe encontrar su tenant.
+// The filter searches by name and by ID: pasting a GUID must find its tenant.
 func TestFilterValueCoversNameAndID(t *testing.T) {
 	item := NewTenantItem(tenants()[0], false, false)
 	got := item.FilterValue()
 	if !strings.Contains(got, "acme") {
-		t.Errorf("FilterValue() = %q, quería que incluyera el nombre", got)
+		t.Errorf("FilterValue() = %q, wanted it to include the name", got)
 	}
 	if !strings.Contains(got, "11111111-1111-1111-1111-111111111111") {
-		t.Errorf("FilterValue() = %q, quería que incluyera el tenant ID", got)
+		t.Errorf("FilterValue() = %q, wanted it to include the tenant ID", got)
 	}
 }
 
@@ -155,70 +155,69 @@ func TestWindowSizeMsgResizesList(t *testing.T) {
 	m := NewModel(tenants(), "", "", nil)
 	m, _ = send(t, m, tea.WindowSizeMsg{Width: 120, Height: 40})
 	if w := m.list.Width(); w >= 120 {
-		t.Errorf("ancho de la lista = %d, quería descontar el margen de 120", w)
+		t.Errorf("list width = %d, wanted the margin discounted from 120", w)
 	}
 	if h := m.list.Height(); h >= 40 {
-		t.Errorf("alto de la lista = %d, quería descontar el margen de 40", h)
+		t.Errorf("list height = %d, wanted the margin discounted from 40", h)
 	}
 }
 
-// El delegate pinta dos líneas por tenant, nombre e ID, y marca el activo.
+// The delegate renders two lines per tenant, name and ID, and marks the active one.
 func TestDelegateRender(t *testing.T) {
 	ts := tenants()
 	m := NewModel(ts, ts[0].ConfigDir, "", nil)
 	d := newDelegate()
 
 	if got := d.Height(); got != 2 {
-		t.Errorf("Height() = %d, quería 2 (nombre + ID)", got)
+		t.Errorf("Height() = %d, wanted 2 (name + ID)", got)
 	}
 
 	var buf bytes.Buffer
 	d.Render(&buf, m.list, 0, m.list.Items()[0])
 	out := buf.String()
 	if !strings.Contains(out, "acme") {
-		t.Errorf("render = %q, quería el nombre", out)
+		t.Errorf("render = %q, wanted the name", out)
 	}
 	if !strings.Contains(out, ts[0].TenantID) {
-		t.Errorf("render = %q, quería el tenant ID", out)
+		t.Errorf("render = %q, wanted the tenant ID", out)
 	}
 	if !strings.Contains(out, "*") {
-		t.Errorf("render = %q, quería el marcador «*» del tenant activo", out)
+		t.Errorf("render = %q, wanted the active tenant's \"*\" marker", out)
 	}
 
 	buf.Reset()
 	d.Render(&buf, m.list, 1, m.list.Items()[1])
 	if out := buf.String(); strings.Contains(out, "*") {
-		t.Errorf("render del tenant inactivo = %q, no quería marcador", out)
+		t.Errorf("render of the inactive tenant = %q, wanted no marker", out)
 	}
 }
 
-// El marcador vive en un solo sitio. Antes existía dos veces —en Title() y
-// reimplementado en el delegate— y solo se usaba la copia del delegate, así
-// que las dos podían divergir sin que nada lo notara.
+// The marker lives in a single place. It used to exist twice —in Title() and
+// reimplemented in the delegate— and only the delegate's copy was used, so the
+// two could diverge without anything noticing.
 func TestMarker(t *testing.T) {
 	ts := tenants()
 
 	active := NewTenantItem(ts[0], true, false).marker()
 	if !strings.Contains(active, "*") {
-		t.Errorf("marcador activo = %q, quería que incluyera «*»", active)
+		t.Errorf("active marker = %q, wanted it to include \"*\"", active)
 	}
 	inactive := NewTenantItem(ts[0], false, false).marker()
 	if strings.Contains(inactive, "*") {
-		t.Errorf("marcador inactivo = %q, no quería «*»", inactive)
+		t.Errorf("inactive marker = %q, wanted no \"*\"", inactive)
 	}
-	// Ambos ocupan dos columnas para que los nombres queden alineados.
+	// Both take two columns so that names stay aligned.
 	if got := len(ansi.Strip(inactive)); got != 2 {
-		t.Errorf("ancho del marcador inactivo = %d, quería 2", got)
+		t.Errorf("inactive marker width = %d, wanted 2", got)
 	}
 	if got := len(ansi.Strip(active)); got != 2 {
-		t.Errorf("ancho del marcador activo = %d, quería 2", got)
+		t.Errorf("active marker width = %d, wanted 2", got)
 	}
 }
 
-// Seleccionado o no, el ítem muestra los mismos datos. Lo que cambia es el
-// adorno: el estilo seleccionado añade un borde izquierdo, que es contenido
-// real y no un código de escape, así que no se pueden comparar las cadenas
-// tal cual.
+// Selected or not, the item shows the same data. What changes is the
+// adornment: the selected style adds a left border, which is real content and
+// not an escape code, so the strings can't be compared as-is.
 func TestDelegateRenderShowsSameDataSelectedOrNot(t *testing.T) {
 	ts := tenants()
 	m := NewModel(ts, "", "", nil)
@@ -229,23 +228,23 @@ func TestDelegateRenderShowsSameDataSelectedOrNot(t *testing.T) {
 	d.Render(&normal, m.list, m.list.Index()+1, m.list.Items()[m.list.Index()])
 
 	for label, out := range map[string]string{
-		"seleccionado": ansi.Strip(selected.String()),
-		"normal":       ansi.Strip(normal.String()),
+		"selected": ansi.Strip(selected.String()),
+		"normal":   ansi.Strip(normal.String()),
 	} {
 		if !strings.Contains(out, ts[0].Name) {
-			t.Errorf("render %s = %q, quería el nombre", label, out)
+			t.Errorf("render %s = %q, wanted the name", label, out)
 		}
 		if !strings.Contains(out, ts[0].TenantID) {
-			t.Errorf("render %s = %q, quería el tenant ID", label, out)
+			t.Errorf("render %s = %q, wanted the tenant ID", label, out)
 		}
 		if lines := strings.Count(out, "\n") + 1; lines != 2 {
-			t.Errorf("render %s tiene %d líneas, quería 2 (nombre + ID)", label, lines)
+			t.Errorf("render %s has %d lines, wanted 2 (name + ID)", label, lines)
 		}
 	}
 }
 
-// helpKeys devuelve las teclas visibles en la barra de ayuda. Las bindings
-// deshabilitadas están en el slice pero el componente de ayuda no las pinta.
+// helpKeys returns the keys visible in the help bar. Disabled bindings are in
+// the slice but the help component does not render them.
 func helpKeys(m Model) []string {
 	var keys []string
 	for _, b := range m.list.ShortHelp() {
@@ -256,9 +255,9 @@ func helpKeys(m Model) []string {
 	return keys
 }
 
-// list.Model.ShortHelp intercala las bindings del delegate entre las teclas
-// de cursor y su propio KeyMap, que ya aporta Filter y Quit. Declararlas
-// también en el delegate las imprimía dos veces.
+// list.Model.ShortHelp interleaves the delegate's bindings between the cursor
+// keys and its own KeyMap, which already provides Filter and Quit. Declaring
+// them in the delegate too printed them twice.
 func TestHelpHasNoDuplicateKeys(t *testing.T) {
 	m := NewModel(tenants(), "", "", nil)
 
@@ -268,13 +267,13 @@ func TestHelpHasNoDuplicateKeys(t *testing.T) {
 	}
 	for k, n := range seen {
 		if n > 1 {
-			t.Errorf("la tecla %q aparece %d veces en la ayuda: %v", k, n, helpKeys(m))
+			t.Errorf("key %q appears %d times in the help: %v", k, n, helpKeys(m))
 		}
 	}
 }
 
-// El delegate solo debe aportar lo que el list no sabe. enter lo maneja él;
-// «/» y «q» las pone el list por su cuenta.
+// The delegate should only add what the list doesn't know. enter it handles;
+// "/" and "q" the list provides on its own.
 func TestHelpContentsAreComplete(t *testing.T) {
 	m := NewModel(tenants(), "", "", nil)
 	keys := helpKeys(m)
@@ -289,31 +288,31 @@ func TestHelpContentsAreComplete(t *testing.T) {
 	}
 	for _, want := range []string{"enter", "/", "q"} {
 		if !has(want) {
-			t.Errorf("falta %q en la ayuda: %v", want, keys)
+			t.Errorf("missing %q in the help: %v", want, keys)
 		}
 	}
 
-	// El delegate declara solo las teclas que el list no conoce: enter y d.
-	// «/» y «q» las aporta el list, y no deben repetirse (#21).
+	// The delegate declares only the keys the list doesn't know: enter and d.
+	// "/" and "q" are provided by the list, and must not be repeated (#21).
 	declared := map[string]bool{}
 	for _, b := range newDelegate().ShortHelp() {
 		declared[b.Help().Key] = true
 	}
 	if !declared["enter"] || !declared["d"] {
-		t.Errorf("el delegate debe declarar enter y d, tiene %v", declared)
+		t.Errorf("the delegate must declare enter and d, has %v", declared)
 	}
 	if declared["/"] || declared["q"] {
-		t.Errorf("el delegate no debe declarar / ni q (los pone el list): %v", declared)
+		t.Errorf("the delegate must not declare / or q (the list provides them): %v", declared)
 	}
 }
 
-// Con el filtro abierto la barra cambia de forma: el list omite el ShortHelp
-// del delegate. Tampoco ahí debe haber repeticiones.
+// With the filter open the bar changes shape: the list omits the delegate's
+// ShortHelp. There too there must be no repetitions.
 func TestHelpHasNoDuplicateKeysWhileFiltering(t *testing.T) {
 	m := NewModel(tenants(), "", "", nil)
 	m, _ = send(t, m, keyMsg("/"))
 	if m.list.FilterState() != list.Filtering {
-		t.Fatalf("no se entró en modo filtro: %v", m.list.FilterState())
+		t.Fatalf("did not enter filter mode: %v", m.list.FilterState())
 	}
 
 	seen := map[string]int{}
@@ -322,12 +321,12 @@ func TestHelpHasNoDuplicateKeysWhileFiltering(t *testing.T) {
 	}
 	for k, n := range seen {
 		if n > 1 {
-			t.Errorf("filtrando, la tecla %q aparece %d veces: %v", k, n, helpKeys(m))
+			t.Errorf("while filtering, key %q appears %d times: %v", k, n, helpKeys(m))
 		}
 	}
 }
 
-// Y la comprobación de extremo a extremo, sobre lo que el usuario ve.
+// And the end-to-end check, over what the user sees.
 func TestRenderedHelpHasNoRepeatedEntries(t *testing.T) {
 	m := NewModel(tenants(), "", "", nil)
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 14})
@@ -335,13 +334,13 @@ func TestRenderedHelpHasNoRepeatedEntries(t *testing.T) {
 
 	for _, entry := range []string{"/ filter", "q quit", "enter activate"} {
 		if got := strings.Count(view, entry); got != 1 {
-			t.Errorf("%q aparece %d veces en la vista, quería 1:\n%s", entry, got, view)
+			t.Errorf("%q appears %d times in the view, wanted 1:\n%s", entry, got, view)
 		}
 	}
 }
 
-// El marcador distingue las cuatro combinaciones de activo y default, y
-// mantiene dos columnas en todas para que los nombres queden alineados.
+// The marker distinguishes the four combinations of active and default, and
+// keeps two columns in all of them so that names stay aligned.
 func TestMarkerDefaultAndActive(t *testing.T) {
 	ts := tenants()
 	cases := []struct {
@@ -349,53 +348,53 @@ func TestMarkerDefaultAndActive(t *testing.T) {
 		active, isDef   bool
 		wantStar, wantD bool
 	}{
-		{"ninguno", false, false, false, false},
-		{"solo activo", true, false, true, false},
-		{"solo default", false, true, false, true},
-		{"ambos", true, true, true, true},
+		{"none", false, false, false, false},
+		{"only active", true, false, true, false},
+		{"only default", false, true, false, true},
+		{"both", true, true, true, true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			m := ansi.Strip(NewTenantItem(ts[0], c.active, c.isDef).marker())
 			if strings.Contains(m, "*") != c.wantStar {
-				t.Errorf("marcador %q: presencia de «*» = %v, quería %v", m, strings.Contains(m, "*"), c.wantStar)
+				t.Errorf("marker %q: presence of \"*\" = %v, wanted %v", m, strings.Contains(m, "*"), c.wantStar)
 			}
 			if strings.Contains(m, "D") != c.wantD {
-				t.Errorf("marcador %q: presencia de «D» = %v, quería %v", m, strings.Contains(m, "D"), c.wantD)
+				t.Errorf("marker %q: presence of \"D\" = %v, wanted %v", m, strings.Contains(m, "D"), c.wantD)
 			}
 			if len(m) != 2 {
-				t.Errorf("marcador %q mide %d columnas, quería 2", m, len(m))
+				t.Errorf("marker %q measures %d columns, wanted 2", m, len(m))
 			}
 		})
 	}
 }
 
-// NewModel marca como default el tenant cuyo nombre coincide, sin distinguir
-// mayúsculas, y ninguno si el nombre está vacío.
+// NewModel marks as default the tenant whose name matches, case-insensitively,
+// and none if the name is empty.
 func TestNewModelMarksDefault(t *testing.T) {
 	ts := tenants() // acme, globex
 	m := NewModel(ts, "", "GLOBEX", nil)
 	items := m.list.Items()
 	if items[0].(TenantItem).isDefault {
-		t.Error("acme marcado como default")
+		t.Error("acme marked as default")
 	}
 	if !items[1].(TenantItem).isDefault {
-		t.Error("globex no marcado como default pese a coincidir (case-insensitive)")
+		t.Error("globex not marked as default despite matching (case-insensitive)")
 	}
 
 	none := NewModel(ts, "", "", nil)
 	for _, it := range none.list.Items() {
 		if it.(TenantItem).isDefault {
-			t.Error("hay un default marcado con defaultName vacío")
+			t.Error("a default is marked with an empty defaultName")
 		}
 	}
 }
 
-// Activo y default son independientes: el render los muestra a la vez cuando
-// coinciden en el mismo tenant, y por separado cuando no.
+// Active and default are independent: the render shows them together when they
+// coincide on the same tenant, and separately when not.
 func TestDelegateRendersDefaultMarker(t *testing.T) {
 	ts := tenants()
-	// acme activo, globex default.
+	// acme active, globex default.
 	m := NewModel(ts, ts[0].ConfigDir, "globex", nil)
 	d := newDelegate()
 
@@ -404,37 +403,37 @@ func TestDelegateRendersDefaultMarker(t *testing.T) {
 	d.Render(&globex, m.list, 1, m.list.Items()[1])
 
 	if a := ansi.Strip(acme.String()); !strings.Contains(a, "*") || strings.Contains(a[:3], "D") {
-		t.Errorf("acme debería ser activo y no default: %q", a)
+		t.Errorf("acme should be active and not default: %q", a)
 	}
 	if g := ansi.Strip(globex.String()); !strings.Contains(g[:3], "D") {
-		t.Errorf("globex debería mostrar el marcador de default: %q", g)
+		t.Errorf("globex should show the default marker: %q", g)
 	}
 }
 
-// La tecla "d" pide confirmación antes de fijar el default, porque reescribe
-// ~/.azure — la única acción de la TUI con efecto en disco.
+// The "d" key asks for confirmation before setting the default, because it
+// rewrites ~/.azure — the only TUI action with an effect on disk.
 func TestSetDefaultKeyAsksConfirmation(t *testing.T) {
 	ts := tenants()
 	var called []string
 	set := func(name string) (string, error) { called = append(called, name); return "", nil }
 	m := NewModel(ts, "", "", set)
 
-	// d sobre el primer item entra en confirmación, sin fijar aún.
+	// d on the first item enters confirmation, without setting yet.
 	m, _ = send(t, m, keyMsg("d"))
 	if !strings.Contains(m.View(), "as the default?") {
-		t.Errorf("d no mostró la confirmación:\n%s", ansi.Strip(m.View()))
+		t.Errorf("d did not show the confirmation:\n%s", ansi.Strip(m.View()))
 	}
 	if len(called) != 0 {
-		t.Errorf("se fijó el default antes de confirmar: %v", called)
+		t.Errorf("the default was set before confirming: %v", called)
 	}
 
-	// y confirma: se fija y el marcador se actualiza.
+	// and confirm: it sets and the marker updates.
 	m, _ = send(t, m, keyMsg("y"))
 	if len(called) != 1 || called[0] != ts[0].Name {
-		t.Fatalf("setDefault llamado con %v, quería [%s]", called, ts[0].Name)
+		t.Fatalf("setDefault called with %v, wanted [%s]", called, ts[0].Name)
 	}
 	if !m.list.Items()[0].(TenantItem).isDefault {
-		t.Error("el marcador de default no se actualizó tras confirmar")
+		t.Error("the default marker did not update after confirming")
 	}
 }
 
@@ -447,14 +446,14 @@ func TestSetDefaultKeyCancelled(t *testing.T) {
 	m, _ = send(t, m, keyMsg("d"))
 	m, _ = send(t, m, keyMsg("n"))
 	if len(called) != 0 {
-		t.Errorf("n no canceló: se fijó %v", called)
+		t.Errorf("n did not cancel: %v was set", called)
 	}
 	if strings.Contains(m.View(), "as the default?") {
-		t.Error("sigue mostrando la confirmación tras cancelar")
+		t.Error("still showing the confirmation after cancelling")
 	}
 }
 
-// Un error al fijar se muestra, no se traga.
+// An error while setting is shown, not swallowed.
 func TestSetDefaultKeyReportsError(t *testing.T) {
 	ts := tenants()
 	set := func(name string) (string, error) { return "", errTest }
@@ -462,21 +461,21 @@ func TestSetDefaultKeyReportsError(t *testing.T) {
 	m, _ = send(t, m, keyMsg("d"))
 	m, _ = send(t, m, keyMsg("y"))
 	if !strings.Contains(m.View(), "Could not set default") {
-		t.Errorf("no se mostró el error:\n%s", ansi.Strip(m.View()))
+		t.Errorf("the error was not shown:\n%s", ansi.Strip(m.View()))
 	}
 }
 
-// Sin callback (setDefault nil), la tecla d no hace nada.
+// Without a callback (setDefault nil), the d key does nothing.
 func TestSetDefaultKeyNoopWithoutCallback(t *testing.T) {
 	m := NewModel(tenants(), "", "", nil)
 	m, _ = send(t, m, keyMsg("d"))
 	if strings.Contains(m.View(), "as the default?") {
-		t.Error("d entró en confirmación sin callback")
+		t.Error("d entered confirmation without a callback")
 	}
 }
 
-// Durante el filtrado, "d" es texto de búsqueda, no la orden de fijar default
-// — la misma guarda que protege a "q" (#7).
+// While filtering, "d" is search text, not the command to set default — the
+// same guard that protects "q" (#7).
 func TestSetDefaultKeyIsTextWhileFiltering(t *testing.T) {
 	ts := tenants()
 	var called []string
@@ -485,14 +484,14 @@ func TestSetDefaultKeyIsTextWhileFiltering(t *testing.T) {
 
 	m, _ = send(t, m, keyMsg("/"))
 	if m.list.FilterState() != list.Filtering {
-		t.Fatalf("no se entró en filtrado")
+		t.Fatalf("did not enter filtering")
 	}
 	m, _ = send(t, m, keyMsg("d"))
 	if strings.Contains(m.View(), "as the default?") {
-		t.Error("d abrió la confirmación durante el filtrado")
+		t.Error("d opened the confirmation while filtering")
 	}
 	if len(called) != 0 {
-		t.Errorf("d fijó el default durante el filtrado: %v", called)
+		t.Errorf("d set the default while filtering: %v", called)
 	}
 }
 


### PR DESCRIPTION
The last pocket of Spanish in the repo. Closes #31.

## What

Comments and assertion messages across the test files (written in Spanish during development), plus developer comments in `.golangci.yml`, `.goreleaser.yaml` and `.github/workflows/ci.yaml`.

**None of this ships in the binary** — tests aren't compiled in, and those are build/CI config — so it changes no behaviour and not a byte of the executable. Production code and all user-facing strings were already English. This is purely so the repo reads as English throughout.

## Scope

- Go comments and `t.Errorf`/`t.Fatalf`/… diagnostics → English.
- Test-data literals that read as Spanish → translated consistently on both the write and the assert within each test (a fake token file's contents `{"credenciales":"valiosas"}` → `{"credentials":"valuable"}`, an invalid-tenant-ID input echoed back in its own error, throwaway filenames, nonexistent-tenant args).
- Left as-is: the `"acmé"` fixture — its accent is the point of the accented-name rejection test.

Done by three parallel translators over disjoint files (cmd, config, azure+tui+config-files), each self-verifying, then a consolidation pass for the remaining data literals.

## Verification

- `go test -race ./...` green; the opt-in real-`az` integration tests green.
- `golangci-lint` and `gofmt` clean; YAML still parses.
- Repo-wide grep finds no Spanish left, bar the `acmé` fixture.
- The diff touches only `*_test.go` and the three config files — nothing in the compiled code.

Closes #31
